### PR TITLE
Add `clear` to `WidgetList`

### DIFF
--- a/src/widget.rs
+++ b/src/widget.rs
@@ -2160,6 +2160,11 @@ impl WidgetList {
         self.ordered.truncate(length);
     }
 
+    /// Clear the list
+    pub fn clear(&mut self) {
+        self.ordered.clear();
+    }
+
     /// Returns `self` as a vertical [`Stack`] of rows.
     #[must_use]
     pub fn into_rows(self) -> Stack {


### PR DESCRIPTION
Currently you have to call `truncate(0)` instead, which isn't ergonomic.