### PR TITLE
Fix some docstrings in window module

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -117,7 +117,7 @@ pub trait PlatformWindowImplementation {
         self.winit().map_or(true, |win| win.is_resizable())
     }
 
-    /// Returns true if the window can have its size changed.
+    /// Returns the underlying window theme.
     ///
     /// The provided implementation returns [`winit::window::Window::theme`], or
     /// dark if this window has no winit window.
@@ -248,7 +248,7 @@ pub trait PlatformWindow {
     fn handle(&self) -> WindowHandle;
     /// Returns the unique id of the [`Kludgine`] instance used by this window.
     fn kludgine_id(&self) -> KludgineId;
-    /// Returns the dynamic that is synchrnoized with the window's focus.
+    /// Returns the dynamic that is synchronized with the window's focus.
     fn focused(&self) -> &Dynamic<bool>;
     /// Returns the dynamic that is synchronized with the window's occlusion
     /// status.
@@ -800,7 +800,7 @@ where
         self
     }
 
-    /// Sets `position`  to be a dynamic synchronized with this window's outer
+    /// Sets `position` to be a dynamic synchronized with this window's outer
     /// position.
     ///
     /// If `automatic_layout` is true, the initial value of `position` will be
@@ -829,7 +829,7 @@ where
         self
     }
 
-    /// Sets `position`  to be a dynamic synchronized with this window's inner
+    /// Sets `position` to be a dynamic synchronized with this window's inner
     /// position.
     ///
     /// When the window is moved, this dynamic will contain its new position.


### PR DESCRIPTION
Just a few minor docstring fixes from skimming the code.