### PR TITLE
Defer change callbacks to a worker thread

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,19 +2,59 @@ name: Docs
 
 on: [push]
 
+env:
+  # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
+  VULKAN_SDK_VERSION: "1.3.290"
+  MESA_VERSION: "24.2.3"
+  CI_BINARY_BUILD: "build19"
+
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install x11 dependencies for Kludgine
+      # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
+      - name: install vulkan sdk
+        shell: bash
         run: |
+          set -e
+
           sudo apt-get update -y -qq
-          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+
+          # vulkan sdk
+          wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-$VULKAN_SDK_VERSION-jammy.list https://packages.lunarg.com/vulkan/$VULKAN_SDK_VERSION/lunarg-vulkan-$VULKAN_SDK_VERSION-jammy.list
+
           sudo apt-get update
-          sudo apt-get install -y \
-            libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers libdbus-1-dev pkg-config
+          sudo apt install -y vulkan-sdk
+
+      # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml  
+      - name: install mesa
+        shell: bash
+        run: |
+          set -e
+
+          curl -L --retry 5 https://github.com/gfx-rs/ci-build/releases/download/$CI_BINARY_BUILD/mesa-$MESA_VERSION-linux-x86_64.tar.xz -o mesa.tar.xz
+          mkdir mesa
+          tar xpf mesa.tar.xz -C mesa
+
+          # The ICD provided by the mesa build is hardcoded to the build environment.
+          #
+          # We write out our own ICD file to point to the mesa vulkan
+          cat <<- EOF > icd.json
+          {
+            "ICD": {
+                "api_version": "1.1.255",
+                "library_path": "$PWD/mesa/lib/x86_64-linux-gnu/libvulkan_lvp.so"
+            },
+            "file_format_version": "1.0.0"
+          }
+          EOF
+
+          echo "VK_DRIVER_FILES=$PWD/icd.json" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$PWD/mesa/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LIBGL_DRIVERS_PATH=$PWD/mesa/lib/x86_64-linux-gnu/dri" >> "$GITHUB_ENV"
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,59 +2,19 @@ name: Docs
 
 on: [push]
 
-env:
-  # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
-  VULKAN_SDK_VERSION: "1.3.290"
-  MESA_VERSION: "24.2.3"
-  CI_BINARY_BUILD: "build19"
-
 jobs:
   docs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
-      # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
-      - name: install vulkan sdk
-        shell: bash
+      - name: Install x11 dependencies for Kludgine
         run: |
-          set -e
-
           sudo apt-get update -y -qq
-
-          # vulkan sdk
-          wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-$VULKAN_SDK_VERSION-jammy.list https://packages.lunarg.com/vulkan/$VULKAN_SDK_VERSION/lunarg-vulkan-$VULKAN_SDK_VERSION-jammy.list
-
+          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
           sudo apt-get update
-          sudo apt install -y vulkan-sdk
-
-      # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml  
-      - name: install mesa
-        shell: bash
-        run: |
-          set -e
-
-          curl -L --retry 5 https://github.com/gfx-rs/ci-build/releases/download/$CI_BINARY_BUILD/mesa-$MESA_VERSION-linux-x86_64.tar.xz -o mesa.tar.xz
-          mkdir mesa
-          tar xpf mesa.tar.xz -C mesa
-
-          # The ICD provided by the mesa build is hardcoded to the build environment.
-          #
-          # We write out our own ICD file to point to the mesa vulkan
-          cat <<- EOF > icd.json
-          {
-            "ICD": {
-                "api_version": "1.1.255",
-                "library_path": "$PWD/mesa/lib/x86_64-linux-gnu/libvulkan_lvp.so"
-            },
-            "file_format_version": "1.0.0"
-          }
-          EOF
-
-          echo "VK_DRIVER_FILES=$PWD/icd.json" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$PWD/mesa/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-          echo "LIBGL_DRIVERS_PATH=$PWD/mesa/lib/x86_64-linux-gnu/dri" >> "$GITHUB_ENV"
+          sudo apt-get install -y \
+            libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers libdbus-1-dev pkg-config
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -74,7 +74,7 @@ jobs:
           to: /${{ github.ref_name }}/docs
 
   guide:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,19 +20,50 @@ jobs:
           sudo docker rmi $(docker image ls -aq) || true
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
 
-      - name: Install x11 dependencies for Kludgine
+
+      # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
+      - name: install vulkan sdk
         if: matrix.os == 'ubuntu-latest'
+        shell: bash
         run: |
+          set -e
+
           sudo apt-get update -y -qq
 
           # vulkan sdk
           wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-$VULKAN_SDK_VERSION-jammy.list https://packages.lunarg.com/vulkan/$VULKAN_SDK_VERSION/lunarg-vulkan-$VULKAN_SDK_VERSION-jammy.list
 
-          # install dependencies
           sudo apt-get update
-          sudo apt-get install -y \
-            libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers libdbus-1-dev pkg-config
+          sudo apt install -y vulkan-sdk
+
+      # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml  
+      - name: install mesa
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -e
+
+          curl -L --retry 5 https://github.com/gfx-rs/ci-build/releases/download/$CI_BINARY_BUILD/mesa-$MESA_VERSION-linux-x86_64.tar.xz -o mesa.tar.xz
+          mkdir mesa
+          tar xpf mesa.tar.xz -C mesa
+
+          # The ICD provided by the mesa build is hardcoded to the build environment.
+          #
+          # We write out our own ICD file to point to the mesa vulkan
+          cat <<- EOF > icd.json
+          {
+            "ICD": {
+                "api_version": "1.1.255",
+                "library_path": "$PWD/mesa/lib/x86_64-linux-gnu/libvulkan_lvp.so"
+            },
+            "file_format_version": "1.0.0"
+          }
+          EOF
+
+          echo "VK_DRIVER_FILES=$PWD/icd.json" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$PWD/mesa/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LIBGL_DRIVERS_PATH=$PWD/mesa/lib/x86_64-linux-gnu/dri" >> "$GITHUB_ENV"
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,50 +20,19 @@ jobs:
           sudo docker rmi $(docker image ls -aq) || true
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
 
-
-      # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
-      - name: install vulkan sdk
+      - name: Install x11 dependencies for Kludgine
         if: matrix.os == 'ubuntu-22.04'
-        shell: bash
         run: |
-          set -e
-
           sudo apt-get update -y -qq
 
           # vulkan sdk
           wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-$VULKAN_SDK_VERSION-jammy.list https://packages.lunarg.com/vulkan/$VULKAN_SDK_VERSION/lunarg-vulkan-$VULKAN_SDK_VERSION-jammy.list
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
 
+          # install dependencies
           sudo apt-get update
-          sudo apt install -y vulkan-sdk
-
-      # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml  
-      - name: install mesa
-        if: matrix.os == 'ubuntu-22.04'
-        shell: bash
-        run: |
-          set -e
-
-          curl -L --retry 5 https://github.com/gfx-rs/ci-build/releases/download/$CI_BINARY_BUILD/mesa-$MESA_VERSION-linux-x86_64.tar.xz -o mesa.tar.xz
-          mkdir mesa
-          tar xpf mesa.tar.xz -C mesa
-
-          # The ICD provided by the mesa build is hardcoded to the build environment.
-          #
-          # We write out our own ICD file to point to the mesa vulkan
-          cat <<- EOF > icd.json
-          {
-            "ICD": {
-                "api_version": "1.1.255",
-                "library_path": "$PWD/mesa/lib/x86_64-linux-gnu/libvulkan_lvp.so"
-            },
-            "file_format_version": "1.0.0"
-          }
-          EOF
-
-          echo "VK_DRIVER_FILES=$PWD/icd.json" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$PWD/mesa/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-          echo "LIBGL_DRIVERS_PATH=$PWD/mesa/lib/x86_64-linux-gnu/dri" >> "$GITHUB_ENV"
+          sudo apt-get install -y \
+            libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers libdbus-1-dev pkg-config
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,14 +8,14 @@ jobs:
       fail-fast: false
       matrix:
         version: ["stable", "1.80.0"]
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-22.04", "windows-latest", "macos-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 
       -
         name: Free disk space
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo docker rmi $(docker image ls -aq) || true
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
@@ -23,7 +23,7 @@ jobs:
 
       # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml
       - name: install vulkan sdk
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         shell: bash
         run: |
           set -e
@@ -39,7 +39,7 @@ jobs:
 
       # Sourced from https://github.com/gfx-rs/wgpu/blob/trunk/.github/workflows/ci.yml  
       - name: install mesa
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         shell: bash
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   drastically differently. If this affects your user interface, use
   `expand_horizontally()` or `expand_vertically()` to limit the direction of the
   expansion.
+- All callbacks executed by map_each/for_each/etc are now executed by a single
+  thread rather than in the thread causing the change. The major effect of this
+  change is that updating a dynamic and immediately trying to read a value of a
+  dynamic that is supposed to be updated will not work reliably anymore. Using a
+  DynamicReader to block until the value is updated will work in existing code
+  and in the new callback execution model.
+
+  This change was made to make complex data flows simpler to implement without
+  causing deadlocks. Without this change, it was easy in a multi-threaded
+  application to create deadlocks with relatively simple data flows like the new
+  `7guis-timer` example.
 
 ### Changed
 
@@ -394,6 +405,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-lingual/multi-locale support using [Fluent][fluent]. See the
   `localization` module for documentation of this feature, or see the
   `localization.rs` example in the repository to see it in action.
+- `Duration` now has `LinearInterpolation` and `PercentBetween` implementations.
+- `Source::on_change_try` is a new function that executes a callback any time
+  the source is changed.
+- `Dynamic::linked_accessor` is a new function that takes a getter and setter
+  function and returns a `Dynamic` that will execute the getter and setter
+  appropriately when its value is changed.
+- `DynamicRead::read_nonblocking` is a new function that attempts to acquire
+  read access to the dynamic without blocking the current thread.
 
 [fluent]: https://projectfluent.org/
 [139]: https://github.com/khonsulabs/cushy/issues/139

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ native-dialogs = ["dep:rfd"]
 kludgine = { git = "https://github.com/khonsulabs/kludgine", features = [
     "app",
 ] }
-figures = { version = "0.4.0" }
+figures = { version = "0.4.2" }
 alot = "0.3.2"
 interner = "0.2.1"
 kempt = "0.2.1"

--- a/examples/7guis-counter.rs
+++ b/examples/7guis-counter.rs
@@ -1,0 +1,28 @@
+use cushy::value::Dynamic;
+use cushy::widget::MakeWidget;
+use cushy::widgets::label::Displayable;
+use cushy::Run;
+use figures::units::Lp;
+
+fn main() -> cushy::Result {
+    let count = Dynamic::new(0_usize);
+
+    count
+        .to_label()
+        .expand()
+        .and(
+            "Count"
+                .into_button()
+                .on_click(move |_| {
+                    *count.lock() += 1;
+                })
+                .expand(),
+        )
+        .into_columns()
+        .pad()
+        .width(Lp::inches(3))
+        .into_window()
+        .titled("Counter")
+        .resize_to_fit(true)
+        .run()
+}

--- a/examples/7guis-temperature-converter.rs
+++ b/examples/7guis-temperature-converter.rs
@@ -1,0 +1,30 @@
+use cushy::value::Dynamic;
+use cushy::widget::MakeWidget;
+use cushy::widgets::input::InputValue;
+use cushy::Run;
+use figures::units::Lp;
+
+fn main() -> cushy::Result {
+    let celsius = Dynamic::new(100f32);
+    let farenheit = celsius.linked(
+        |celsius| *celsius * 9. / 5. + 32.,
+        |farenheit| (*farenheit - 32.) * 5. / 9.,
+    );
+
+    let celsius_string = celsius.linked_string();
+    let farenheight_string = farenheit.linked_string();
+
+    celsius_string
+        .into_input()
+        .expand()
+        .and("Celsius =")
+        .and(farenheight_string.into_input().expand())
+        .and("Farenheit")
+        .into_columns()
+        .pad()
+        .width(Lp::inches(4))
+        .into_window()
+        .titled("Temperature Converter")
+        .resize_to_fit(true)
+        .run()
+}

--- a/examples/7guis-timer.rs
+++ b/examples/7guis-timer.rs
@@ -1,0 +1,86 @@
+use std::time::{Duration, Instant};
+
+use cushy::value::{Destination, Dynamic, DynamicReader, Source};
+use cushy::widget::MakeWidget;
+use cushy::widgets::progress::Progressable;
+use cushy::widgets::slider::Slidable;
+use cushy::{Open, PendingApp};
+use figures::units::Lp;
+
+#[derive(PartialEq, Debug, Clone)]
+struct Timer {
+    started_at: Instant,
+    duration: Duration,
+}
+
+impl Default for Timer {
+    fn default() -> Self {
+        Self {
+            started_at: Instant::now() - Duration::from_secs(1),
+            duration: Duration::from_secs(1),
+        }
+    }
+}
+
+fn main() -> cushy::Result {
+    let pending = PendingApp::default();
+    let cushy = pending.cushy().clone();
+    let _runtime = cushy.enter_runtime();
+
+    let timer = Dynamic::<Timer>::default();
+    let duration = timer.linked_accessor(|timer| &timer.duration, |timer| &mut timer.duration);
+
+    let elapsed = spawn_timer(&timer);
+    let duration_label = duration.map_each(|duration| format!("{}s", duration.as_secs_f32()));
+
+    elapsed
+        .progress_bar_between(
+            duration
+                .weak_clone()
+                .map_each_cloned(|duration| Duration::ZERO..=duration),
+        )
+        .fit_horizontally()
+        .and(duration_label)
+        .and(
+            "Duration"
+                .and(
+                    duration
+                        .slider_between(Duration::ZERO, Duration::from_secs(30))
+                        .expand_horizontally(),
+                )
+                .into_columns(),
+        )
+        .and("Reset".into_button().on_click(move |_| {
+            timer.lock().started_at = Instant::now();
+        }))
+        .into_rows()
+        .pad()
+        .width(Lp::inches(4))
+        .into_window()
+        .titled("Timer")
+        .resize_to_fit(true)
+        .run_in(pending)
+}
+
+fn spawn_timer(timer: &Dynamic<Timer>) -> DynamicReader<Duration> {
+    let timer = timer.create_reader();
+    let elapsed = Dynamic::new(timer.map_ref(|timer| timer.duration));
+    let elapsed_reader = elapsed.weak_clone().into_reader();
+    std::thread::spawn(move || loop {
+        let settings = timer.get();
+
+        // Update the elapsed time, clamping to the duration of the timer.
+        let duration_since_started = settings.started_at.elapsed().min(settings.duration);
+        elapsed.set(duration_since_started);
+
+        if duration_since_started < settings.duration {
+            // The timer is still running, "tick" the timer by sleeping and
+            // allow the loop to continue.
+            std::thread::sleep(Duration::from_millis(16));
+        } else {
+            // Block the thread until the timer settings have been changed.
+            timer.block_until_updated();
+        }
+    });
+    elapsed_reader
+}

--- a/examples/7guis-timer.rs
+++ b/examples/7guis-timer.rs
@@ -34,11 +34,7 @@ fn main() -> cushy::Result {
     let duration_label = duration.map_each(|duration| format!("{}s", duration.as_secs_f32()));
 
     elapsed
-        .progress_bar_between(
-            duration
-                .weak_clone()
-                .map_each_cloned(|duration| Duration::ZERO..=duration),
-        )
+        .progress_bar_between(duration.map_each_cloned(|duration| Duration::ZERO..=duration))
         .fit_horizontally()
         .and(duration_label)
         .and(
@@ -65,7 +61,7 @@ fn main() -> cushy::Result {
 fn spawn_timer(timer: &Dynamic<Timer>) -> DynamicReader<Duration> {
     let timer = timer.create_reader();
     let elapsed = Dynamic::new(timer.map_ref(|timer| timer.duration));
-    let elapsed_reader = elapsed.weak_clone().into_reader();
+    let elapsed_reader = elapsed.create_reader();
     std::thread::spawn(move || loop {
         let settings = timer.get();
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -1053,6 +1053,27 @@ where
     }
 }
 
+impl LinearInterpolate for Duration {
+    #[allow(clippy::cast_precision_loss)]
+    fn lerp(&self, target: &Self, percent: f32) -> Self {
+        let nanos = self.as_nanos().lerp(&target.as_nanos(), percent);
+        let seconds = nanos / 1_000_000_000;
+        let subsec_nanos = nanos % 1_000_000_000;
+        Self::new(
+            u64::try_from(seconds).unwrap_or(u64::MAX),
+            subsec_nanos as u32,
+        )
+    }
+}
+impl PercentBetween for Duration {
+    fn percent_between(&self, min: &Self, max: &Self) -> ZeroToOne {
+        let this = self.as_secs_f32();
+        let min = min.as_secs_f32();
+        let max = max.as_secs_f32();
+        this.percent_between(&min, &max)
+    }
+}
+
 #[test]
 fn integer_lerps() {
     #[track_caller]
@@ -1156,14 +1177,16 @@ macro_rules! impl_percent_between {
                 clippy::cast_lossless
             )]
             fn percent_between(&self, min: &Self, max: &Self) -> ZeroToOne {
-                assert!(min <= max, "percent_between requires min <= max");
-                assert!(
-                    self >= min && self <= max,
-                    "self must satisfy min <= self <= max"
-                );
-
-                let range = max.$sub(*min);
-                ZeroToOne::from(self.$sub(*min) as $float / range as $float)
+                if min >= max {
+                    return ZeroToOne::ZERO;
+                } else if self <= min {
+                    ZeroToOne::ZERO
+                } else if self >= max {
+                    ZeroToOne::ONE
+                } else {
+                    let range = max.$sub(*min);
+                    ZeroToOne::from(self.$sub(*min) as $float / range as $float)
+                }
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,8 @@ fn initialize_tracing() {
                 Targets::new()
                     .with_target("winit", Level::ERROR)
                     .with_target("wgpu", Level::ERROR)
-                    .with_target("naga", Level::ERROR),
+                    .with_target("naga", Level::ERROR)
+                    .with_default(MAX_LEVEL),
             )
             .try_init();
     }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -2512,18 +2512,8 @@ where
     }
 }
 
-/// Allows to convert collections or iterators directly into [`Stack`], [`Layers`], etc.
-///
-/// ```
-/// use cushy::widget::{IntoWidgetList, MakeWidget};
-///
-/// vec!["hello", "label"].into_rows();
-///
-/// vec!["hello", "button"]
-///     .into_iter()
-///     .map(|l| l.into_button())
-///     .into_columns();
-/// ```
+/// Allows to convert collections or iterators directly into [`Stack`],
+/// [`Layers`], etc.
 pub trait MakeWidgetList: Sized {
     /// Returns self as a `WidgetList`.
     fn make_widget_list(self) -> WidgetList;

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -2484,7 +2484,7 @@ where
 /// Allows to convert collections or iterators directly into [`Stack`], [`Layers`], etc.
 ///
 /// ```
-/// use cushy::widget::{MakeWidget, MakeWidgetList};
+/// use cushy::widget::{IntoWidgetList, MakeWidget};
 ///
 /// vec!["hello", "label"].into_rows();
 ///


### PR DESCRIPTION
This change fundamentally changes how change callbacks work on Dynamics. Prior to this change, callbacks executed on the thread that was performing the change. This could lead to situations where multiple threads were executing callback chains which leads to unpredictable locking patterns on the dynamics. The basic deadlock detection was not enough.

This change defers callbacks to a single callback thread. This thread ensures that no dynamic can have callbacks enqueued more than once. By limiting execution to one set of callbacks at any given time, this greatly reduces the surface for locks to contend with each other.

The next issue was how tuple-related functions like for_each/map_each were acquiring their locks. By calling a.read() then b.read(), this was causing a to be held in a locked state while b was being aquired. If users are careful to always acquire their locks in this order, everything is fine. But with Cushy there can be unexpected situations where these locks are being held.

This change also refactors lock acquisition for tuples to try to acquire all the locks in a non-blocking way. If any lock woould block, the initial locks are dropped while the lock that would block is waited on. After this is acquired the process starts over again to gain all the locks. This isn't perfect, but it doesn't require unsafe. With unsafe, we could in theory create a ring of callbacks that handles acquiring all of the locks into MaybeUninits. Upon successfully calling all callbacks, the values can be assumed init. But writing all of this in macro_rules isn't fun, and the current solution alleviates the main problem