### PR TITLE
Add tree widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
  "easing-function",
  "figures",
  "image",
+ "indexmap",
  "intentional",
  "interner",
  "kempt",
@@ -1075,9 +1076,9 @@ checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ nominals = "0.3.0"
 parking_lot = "0.12.1"
 easing-function = "0.1.1"
 serde = { version = "1.0.210", features = ["derive"], optional = true }
-
+indexmap = "2.7.0"
 
 # [patch.crates-io]
 # cosmic-text = { path = "../cosmic-text" }

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -13,9 +13,14 @@ fn main(app: &mut App) -> cushy::Result {
     let child_key = tree.insert_child("child".to_string(), Some(&root_key)).unwrap();
     let _nested_child_key = tree.insert_child("nested".to_string(), Some(&child_key));
 
-    let ui = pending.with_root(tree
-        .make_widget()
-    )
+    let elements = "content above".contain()
+        .and(tree.contain())
+        .and("content below".contain())
+        .into_rows()
+        .contain()
+        .make_widget();
+
+    let ui = pending.with_root(elements)
         .titled("tree");
     
     ui.open(app)?;

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -10,8 +10,12 @@ fn main(app: &mut App) -> cushy::Result {
   
     let mut tree: Tree = Tree::default();
     let root_key = tree.insert_child("root".to_string(), None).unwrap();
-    let child_key = tree.insert_child("child".to_string(), Some(&root_key)).unwrap();
-    let _nested_child_key = tree.insert_child("nested".to_string(), Some(&child_key));
+    let child_key_1 = tree.insert_child("child 1".to_string(), Some(&root_key)).unwrap();
+    let nested_child_key_1 = tree.insert_child("nested 1".to_string(), Some(&child_key_1)).unwrap();
+    let _nested_child_key_2 = tree.insert_after("nested 2".to_string(), &nested_child_key_1).unwrap();
+    let child_key_2 = tree.insert_child("child 2".to_string(), Some(&root_key)).unwrap();
+    let nested_child_key_3 = tree.insert_child("nested 3".to_string(), Some(&child_key_2)).unwrap();
+    let _nested_child_key_4 = tree.insert_after("nested 4".to_string(), &nested_child_key_3);
 
     let elements = "content above".contain()
         .and(tree.contain())

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -1,0 +1,24 @@
+use cushy::{App, Open, Run};
+use cushy::widget::MakeWidget;
+use cushy::widgets::tree::Tree;
+use cushy::window::PendingWindow;
+
+#[cushy::main]
+fn main(app: &mut App) -> cushy::Result {
+
+    let pending = PendingWindow::default();
+  
+    let mut tree: Tree = Tree::default();
+    let root_key = tree.insert_child("root".to_string(), None).unwrap();
+    let child_key = tree.insert_child("child".to_string(), Some(&root_key)).unwrap();
+    let _nested_child_key = tree.insert_child("nested".to_string(), Some(&child_key));
+
+    let ui = pending.with_root(tree
+        .make_widget()
+    )
+        .titled("tree");
+    
+    ui.open(app)?;
+    
+    Ok(())
+}

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -1,7 +1,38 @@
 use cushy::{App, Open, Run};
 use cushy::widget::MakeWidget;
+use cushy::widgets::label::Displayable;
 use cushy::widgets::tree::Tree;
 use cushy::window::PendingWindow;
+
+fn make_node_with_label_and_buttons(name: &'static str) -> impl MakeWidget {
+    name.into_label()
+        .and("Delete"
+            .into_button()
+            .on_click(|event|{
+                // FIXME here we want to do this, but we have neither the tree nor the key
+                //       tree.remove_node(key);
+            })
+            .make_widget()
+        )
+        .and("Add child"
+            .into_button()
+            .on_click(|event|{
+                // FIXME here we want to do this, but we have neither the tree nor the key
+                //       tree.insert_child(make_node_with_label_and_buttons("generated child"), Some(key));
+            })
+            .make_widget()
+        )
+        .and("Add sibling"
+            .into_button()
+            .on_click(|event|{
+                // FIXME here we want to do this, but we have neither the tree nor the key
+                //       tree.insert_after(make_node_with_label_and_buttons("generated child"), key);
+            })
+            .make_widget()
+        )
+        .into_columns()
+        .make_widget()
+}
 
 #[cushy::main]
 fn main(app: &mut App) -> cushy::Result {
@@ -9,13 +40,13 @@ fn main(app: &mut App) -> cushy::Result {
     let pending = PendingWindow::default();
   
     let mut tree: Tree = Tree::default();
-    let root_key = tree.insert_child("root".to_string(), None).unwrap();
-    let child_key_1 = tree.insert_child("child 1".to_string(), Some(&root_key)).unwrap();
-    let nested_child_key_1 = tree.insert_child("nested 1".to_string(), Some(&child_key_1)).unwrap();
-    let _nested_child_key_2 = tree.insert_after("nested 2".to_string(), &nested_child_key_1).unwrap();
-    let child_key_2 = tree.insert_child("child 2".to_string(), Some(&root_key)).unwrap();
-    let nested_child_key_3 = tree.insert_child("nested 3".to_string(), Some(&child_key_2)).unwrap();
-    let _nested_child_key_4 = tree.insert_after("nested 4".to_string(), &nested_child_key_3);
+    let root_key = tree.insert_child(make_node_with_label_and_buttons("root"), None).unwrap();
+    let child_key_1 = tree.insert_child(make_node_with_label_and_buttons("child 1"), Some(&root_key)).unwrap();
+    let nested_child_key_1 = tree.insert_child(make_node_with_label_and_buttons("nested 1"), Some(&child_key_1)).unwrap();
+    let _nested_child_key_2 = tree.insert_after(make_node_with_label_and_buttons("nested 2"), &nested_child_key_1).unwrap();
+    let child_key_2 = tree.insert_child(make_node_with_label_and_buttons("child 2"), Some(&root_key)).unwrap();
+    let nested_child_key_3 = tree.insert_child(make_node_with_label_and_buttons("nested 3"), Some(&child_key_2)).unwrap();
+    let _nested_child_key_4 = tree.insert_after(make_node_with_label_and_buttons("nested 4"), &nested_child_key_3);
 
     let elements = "content above".contain()
         .and(tree.contain())

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -1,32 +1,48 @@
+
 use cushy::{App, Open, Run};
-use cushy::widget::MakeWidget;
+use cushy::value::Dynamic;
+use cushy::widget::{MakeWidget, WidgetInstance};
 use cushy::widgets::label::Displayable;
-use cushy::widgets::tree::Tree;
+use cushy::widgets::tree::{Tree, TreeNodeKey};
 use cushy::window::PendingWindow;
 
-fn make_node_with_label_and_buttons(name: &'static str) -> impl MakeWidget {
+
+fn make_node_with_label_and_buttons_f(tree: Dynamic<Tree>, key: TreeNodeKey, name: &'static str) -> WidgetInstance {
     name.into_label()
         .and("Delete"
             .into_button()
-            .on_click(|event|{
-                // FIXME here we want to do this, but we have neither the tree nor the key
-                //       tree.remove_node(key);
+            .on_click({
+                let tree = tree.clone();
+                let key = key.clone();
+                move |event|{
+                    tree.lock().remove_node(&key);
+                }
             })
             .make_widget()
         )
         .and("Add child"
             .into_button()
-            .on_click(|event|{
-                // FIXME here we want to do this, but we have neither the tree nor the key
-                //       tree.insert_child(make_node_with_label_and_buttons("generated child"), Some(key));
+            .on_click({
+                let tree = tree.clone();
+                let key = key.clone();
+                move |event|{
+                    tree.lock().insert_child_f(|child_key|{
+                        make_node_with_label_and_buttons_f(tree.clone(), child_key.clone(), "generated child").make_widget()
+                    }, Some(&key));
+                }
             })
             .make_widget()
         )
         .and("Add sibling"
             .into_button()
-            .on_click(|event|{
-                // FIXME here we want to do this, but we have neither the tree nor the key
-                //       tree.insert_after(make_node_with_label_and_buttons("generated child"), key);
+            .on_click({
+                let tree = tree.clone();
+                let key = key.clone();
+                move |event|{
+                    tree.lock().insert_after_f(|sibling_key|{
+                        make_node_with_label_and_buttons_f(tree.clone(), sibling_key.clone(), "generated sibling").make_widget()
+                    }, &key);
+                }
             })
             .make_widget()
         )
@@ -34,24 +50,57 @@ fn make_node_with_label_and_buttons(name: &'static str) -> impl MakeWidget {
         .make_widget()
 }
 
+
 #[cushy::main]
 fn main(app: &mut App) -> cushy::Result {
 
     let pending = PendingWindow::default();
   
-    let mut tree: Tree = Tree::default();
-    let root_key = tree.insert_child(make_node_with_label_and_buttons("root"), None).unwrap();
-    let child_key_1 = tree.insert_child(make_node_with_label_and_buttons("child 1"), Some(&root_key)).unwrap();
-    let nested_child_key_1 = tree.insert_child(make_node_with_label_and_buttons("nested 1"), Some(&child_key_1)).unwrap();
-    let _nested_child_key_2 = tree.insert_after(make_node_with_label_and_buttons("nested 2"), &nested_child_key_1).unwrap();
-    let child_key_2 = tree.insert_child(make_node_with_label_and_buttons("child 2"), Some(&root_key)).unwrap();
-    let nested_child_key_3 = tree.insert_child(make_node_with_label_and_buttons("nested 3"), Some(&child_key_2)).unwrap();
-    let _nested_child_key_4 = tree.insert_after(make_node_with_label_and_buttons("nested 4"), &nested_child_key_3);
+    let mut dyn_tree: Dynamic<Tree> = Dynamic::new(Tree::default());
+    let root_key = {
+        let mut tree = dyn_tree.lock();
+
+        let root_key = tree.insert_child_f(|key| {
+            make_node_with_label_and_buttons_f(dyn_tree.clone(), key, "root").make_widget()
+        }, None).unwrap();
+
+        let child_key_1 = tree.insert_child_f(|key| {
+            make_node_with_label_and_buttons_f(dyn_tree.clone(), key,"child 1").make_widget()
+        }, Some(&root_key)).unwrap();
+
+        let nested_child_key_1 = tree.insert_child_f(|key| {
+            make_node_with_label_and_buttons_f(dyn_tree.clone(), key, "nested 1").make_widget()
+        }, Some(&child_key_1)).unwrap();
+
+        let _nested_child_key_2 = tree.insert_after_f(|key| {
+            make_node_with_label_and_buttons_f(dyn_tree.clone(), key, "nested 2")
+        }, &nested_child_key_1).unwrap();
+
+        let child_key_2 = tree.insert_child_f(|key| {
+            make_node_with_label_and_buttons_f(dyn_tree.clone(), key, "child 2").make_widget()
+        }, Some(&root_key)).unwrap();
+
+        let nested_child_key_3 = tree.insert_child_f(|key| {
+            make_node_with_label_and_buttons_f(dyn_tree.clone(), key, "nested 3").make_widget()
+        }, Some(&child_key_2)).unwrap();
+
+        let _nested_child_key_4 = tree.insert_after_f(|key|{
+            make_node_with_label_and_buttons_f(dyn_tree.clone(), key, "nested 4").make_widget()
+        }, &nested_child_key_3);
+
+        root_key
+    };
+
+    let tree_widget = dyn_tree.lock().make_widget();
+
+    // the tree can still be accessed after making a widget
+    let _keys = dyn_tree.lock().children_keys(root_key);
 
     let elements = "content above".contain()
-        .and(tree.contain())
+        .and(tree_widget.contain())
         .and("content below".contain())
         .into_rows()
+        .vertical_scroll()
         .contain()
         .make_widget();
 

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -55,7 +55,7 @@ fn make_node_with_label_and_buttons_f(tree: Dynamic<Tree>, key: TreeNodeKey, nam
 fn main(app: &mut App) -> cushy::Result {
 
     let pending = PendingWindow::default();
-  
+
     let mut dyn_tree: Dynamic<Tree> = Dynamic::new(Tree::default());
     let root_key = {
         let mut tree = dyn_tree.lock();
@@ -100,8 +100,8 @@ fn main(app: &mut App) -> cushy::Result {
         .and(tree_widget.contain())
         .and("content below".contain())
         .into_rows()
-        .vertical_scroll()
         .contain()
+        .vertical_scroll()
         .make_widget();
 
     let ui = pending.with_root(elements)

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 
 use figures::units::{Px, UPx};
 use figures::{
-    self, Fraction, IntoSigned, IntoUnsigned, Point, Rect, ScreenScale, ScreenUnit, Size, Zero,
+    self, Fraction, IntoSigned, IntoUnsigned, Point, Rect, Round, ScreenScale, ScreenUnit, Size, Zero
 };
 use kempt::{map, Map};
 use kludgine::cosmic_text::{fontdb, FamilyOwned, FontSystem};
@@ -285,7 +285,7 @@ impl<'clip, 'gfx, 'pass> Graphics<'clip, 'gfx, 'pass> {
         text: impl Into<Drawable<&'a MeasuredText<Unit>, Unit>>,
         origin: TextOrigin<Unit>,
     ) where
-        Unit: ScreenUnit,
+        Unit: ScreenUnit + Round,
     {
         let mut text = text.into();
         text.opacity = Some(

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -39,6 +39,7 @@ mod tilemap;
 pub mod validated;
 mod virtual_list;
 pub mod wrap;
+pub mod tree;
 
 pub use self::align::Align;
 pub use self::button::Button;

--- a/src/widgets/tree.rs
+++ b/src/widgets/tree.rs
@@ -92,7 +92,7 @@ impl Tree {
             let key = self.generate_next_key(); // Generate key after deciding a node is needed
 
             let child_widget = TreeNodeWidget {
-                is_expanded: false,
+                is_expanded: true,
                 child,
                 child_height: None,
             }.make_widget();
@@ -130,7 +130,7 @@ impl Tree {
             let key = self.generate_next_key(); // Generate key after deciding a node is needed
 
             let child_widget = TreeNodeWidget {
-                is_expanded: false,
+                is_expanded: true,
                 child,
                 child_height: None,
             }.make_widget();

--- a/src/widgets/tree.rs
+++ b/src/widgets/tree.rs
@@ -29,7 +29,7 @@ impl TreeNodeWidget {
 
         let is_expanded = Dynamic::new(true);
 
-        let indicator = is_expanded.map_each(|value|{
+        let indicator = is_expanded.clone().map_each(|value|{
             match value {
                 true => "v",
                 false => ">"
@@ -45,10 +45,17 @@ impl TreeNodeWidget {
             })
             .make_widget();
 
+        let children_switcher = is_expanded.clone().switcher(move |value, active| {
+            match value {
+                false => Space::default().make_widget(),
+                true => children.clone().into_rows().make_widget()
+            }
+        }).make_widget();
+
         let child = expand_button
             .and(child)
             .into_columns()
-            .and(children.into_rows())
+            .and(children_switcher)
             .into_rows()
             // FIXME remove container, just for tree right now.
             .contain()

--- a/src/widgets/tree.rs
+++ b/src/widgets/tree.rs
@@ -43,7 +43,12 @@ impl TreeNodeWidget {
             })
             .make_widget();
 
-        let child = expand_button.and(child).into_columns().into_ref();
+        let child = expand_button
+            .and(child)
+            .into_columns()
+            // FIXME remove container, just for tree right now.
+            .contain()
+            .into_ref();
 
         Self {
             is_expanded,

--- a/src/widgets/tree.rs
+++ b/src/widgets/tree.rs
@@ -1,0 +1,298 @@
+use std::fmt::{Debug, Formatter};
+use cushy::ConstraintLimit;
+use cushy::context::LayoutContext;
+use cushy::figures::Size;
+use cushy::figures::units::Px;
+use cushy::widget::{MakeWidget, WidgetRef, WrappedLayout, WrapperWidget};
+use cushy::widgets::Space;
+use indexmap::IndexMap;
+
+#[derive(Default,Clone, Debug, Hash, PartialEq, Eq)]
+pub struct TreeNodeKey(usize);
+
+pub struct TreeNode {
+    is_expanded: bool,
+    parent: Option<TreeNodeKey>,
+    depth: usize,
+
+    child: WidgetRef,
+    child_height: Option<Px>,
+}
+
+impl Debug for TreeNode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TreeNode")
+            .field("is_expanded", &self.is_expanded)
+            .field("value", &"<...>")
+            .field("parent", &self.parent)
+            .field("depth", &self.depth)
+            .finish()
+    }
+}
+
+
+#[derive(Debug)]
+pub struct Tree {
+    nodes: IndexMap<TreeNodeKey, TreeNode>,
+    next_key: TreeNodeKey,
+    root: WidgetRef,
+}
+
+impl Default for Tree {
+    fn default() -> Self {
+        let root = Space::default().into_ref();
+
+        Self {
+            nodes: IndexMap::new(),
+            next_key: TreeNodeKey::default(),
+            root
+        }
+    }
+}
+impl Tree {
+    fn generate_next_key(&mut self) -> TreeNodeKey {
+        let key = self.next_key.clone();
+        self.next_key.0 += 1;
+        key
+    }
+
+    /// Inserts a child after the given parent
+    pub fn insert_child(&mut self, value: impl MakeWidget, parent: Option<&TreeNodeKey>) -> Option<TreeNodeKey> {
+
+        let child = value.into_ref();
+
+        if let Some(parent) = parent {
+            let depth = if let Some(parent_node) = self.nodes.get(parent) {
+                parent_node.depth + 1
+            } else {
+                return None;
+            };
+
+            let key = self.generate_next_key();
+            let child_node = TreeNode {
+                is_expanded: false,
+                parent: Some(parent.clone()),
+                depth,
+                child,
+                child_height: None,
+            };
+            self.nodes.insert(key.clone(), child_node);
+            Some(key)
+        } else {
+            let key = self.generate_next_key();
+            let root_node = TreeNode {
+                is_expanded: false,
+                parent: None,
+                depth: 0,
+                child,
+                child_height: None,
+            };
+            self.nodes.insert(key.clone(), root_node);
+            Some(key)
+        }
+    }
+
+    /// Inserts a sibling after the given node.
+    ///
+    /// Returns `None` if the given node doesn't exist.
+    pub fn insert_after(&mut self, value: impl MakeWidget, node: &TreeNodeKey) -> Option<TreeNodeKey> {
+        if let Some(existing_node) = self.nodes.get(node) {
+            let child = value.into_ref();
+
+            let sibling_node = TreeNode {
+                is_expanded: false,
+                parent: existing_node.parent.clone(),
+                depth: existing_node.depth,
+                child,
+                child_height: None,
+            };
+            let sibling_key = self.generate_next_key();
+            
+            self.nodes.insert(sibling_key.clone(), sibling_node);
+            
+            Some(sibling_key)
+        } else {
+            None
+        }
+    }
+
+    /// Clears the tree, removing all nodes and resetting the key.
+    pub fn clear(&mut self) {
+        self.nodes.clear();
+        self.next_key = TreeNodeKey::default();
+    }
+
+    /// Removes the node and all descendants.
+    pub fn remove_node(&mut self, node_key: &TreeNodeKey) {
+        // First, check if the node exists
+        if !self.nodes.contains_key(node_key) {
+            return;
+        }
+
+        // Create a stack to hold nodes to be removed
+        let mut to_remove = vec![node_key.clone()];
+
+        // We perform a DFS traversal to collect all descendant keys
+        while let Some(current_key) = to_remove.pop() {
+            if let Some(_node) = self.nodes.shift_remove(&current_key) {
+                // Add children of the current node to the stack
+                self.nodes
+                    .keys()
+                    .filter(|&key| self.nodes[key].parent.as_ref() == Some(&current_key))
+                    .for_each(|key| to_remove.push(key.clone()));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::widget::MakeWidget;
+    use crate::widgets::label::Displayable;
+    use super::Tree;
+    
+    #[test]
+    pub fn add_root() {
+        // given
+        
+        let mut tree = Tree::default();
+        let root_widget = "root".into_label().make_widget();
+        // when
+        
+        let key = tree.insert_child(root_widget, None).unwrap();
+        // when
+        
+        assert_eq!(key.0, 0);
+        assert_eq!(tree.nodes.len(), 1);
+        // and
+        let root = tree.nodes.get(&key).unwrap();
+        
+        assert_eq!(root.parent, None);
+        assert_eq!(root.depth, 0);
+    }
+    
+    #[test]
+    pub fn add_child_to_root() {
+        // given
+        let mut tree = Tree::default();
+        let root_key = tree.insert_child("root".to_string(), None).unwrap();
+
+        // when
+        let child_key = tree.insert_child("child".to_string(), Some(&root_key)).unwrap();
+
+        // then
+        assert_eq!(child_key.0, 1);
+        assert_eq!(tree.nodes.len(), 2);
+
+        // and
+        let child = tree.nodes.get(&child_key).unwrap();
+        assert_eq!(child.parent, Some(root_key.clone()));
+        assert_eq!(child.depth, 1);
+    }
+
+
+    #[test]
+    pub fn add_sibling_to_child() {
+        // given
+        let mut tree = Tree::default();
+        let root_key = tree.insert_child("root".to_string(), None).unwrap();
+        let first_child_key = tree.insert_child("first_child".to_string(), Some(&root_key)).unwrap();
+
+        // when
+        let sibling_key = tree.insert_after("sibling".to_string(), &first_child_key).unwrap();
+
+        // then
+        assert_eq!(tree.nodes.len(), 3);
+
+        // and verify the sibling properties
+        let sibling = tree.nodes.get(&sibling_key).unwrap();
+        assert_eq!(sibling.parent, Some(root_key.clone()));
+        assert_eq!(sibling.depth, 1); // Assuming sibling has the same depth as the first child
+    }
+
+
+    #[test]
+    pub fn remove_node() {
+        // given
+        let mut tree = Tree::default();
+        let root_key = tree.insert_child("root".to_string(), None).unwrap();
+        let child_key = tree.insert_child("child".to_string(), Some(&root_key)).unwrap();
+        let _descendant_key = tree.insert_child("descendant".to_string(), Some(&child_key)).unwrap();
+
+        // node to be removed
+        let node_to_remove = root_key.clone();
+
+        // assume we have a remove_node method
+        tree.remove_node(&node_to_remove);
+
+        // then
+        tree.nodes.iter().for_each(|(key, node)| {
+            println!("key: {:?}: node: {:?}", key, node);
+        });
+        // and root, child and descendant nodes should be removed
+        assert_eq!(tree.nodes.len(), 0);
+    }
+
+    #[test]
+    pub fn remove_child_node() {
+        // given
+        
+        // Root
+        // +- 1
+        // |  +- 3
+        // +- 2
+        // |  +- 4
+        
+        
+        let mut tree = Tree::default();
+        let root_key = tree.insert_child("root".to_string(), None).unwrap();
+        // direct children
+        let key_1 = tree.insert_child("1".to_string(), Some(&root_key)).unwrap();
+        let key_2 = tree.insert_child("2".to_string(), Some(&root_key)).unwrap();
+        // descendants
+        let key_3 = tree.insert_child("3".to_string(), Some(&key_1)).unwrap();
+        let _key_4 = tree.insert_child("3".to_string(), Some(&key_2)).unwrap();
+
+        // ensure they exist before removal
+        assert_eq!(tree.nodes.len(), 5);
+        
+        // node to be removed
+        let node_to_remove = key_1.clone();
+
+        // when
+        tree.remove_node(&node_to_remove);
+
+        // then the root node should remain
+        assert_eq!(tree.nodes.len(), 3);
+        assert!(tree.nodes.get(&root_key).is_some());
+
+        // and child and childred should be removed
+        assert!(tree.nodes.get(&key_1).is_none());
+        assert!(tree.nodes.get(&key_3).is_none());
+    }
+}
+
+impl WrapperWidget for TreeNode {
+    fn child_mut(&mut self) -> &mut WidgetRef {
+        &mut self.child
+    }
+
+    fn position_child(&mut self, size: Size<Px>, _available_space: Size<ConstraintLimit>, _context: &mut LayoutContext<'_, '_, '_, '_>) -> WrappedLayout {
+        if self.child_height.is_none() {
+            self.child_height.replace(size.height);
+        }
+
+        let size = match self.is_expanded {
+            true => Size::new(size.width, self.child_height.unwrap()),
+            false => Size::new(size.width, Px::new(0)),
+        };
+
+        size.into()
+    }
+}
+
+impl WrapperWidget for Tree {
+    fn child_mut(&mut self) -> &mut WidgetRef {
+        &mut self.root
+    }
+}

--- a/src/widgets/tree.rs
+++ b/src/widgets/tree.rs
@@ -6,8 +6,9 @@ use cushy::figures::units::Px;
 use cushy::widget::{MakeWidget, WidgetRef, WrappedLayout, WrapperWidget};
 use cushy::widgets::Space;
 use indexmap::IndexMap;
-use crate::value::{Dynamic, Switchable};
+use crate::value::{Destination, Dynamic, Source, Switchable};
 use crate::widget::WidgetInstance;
+use crate::widgets::label::Displayable;
 
 #[derive(Default,Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TreeNodeKey(usize);
@@ -19,9 +20,40 @@ pub struct TreeNode {
 }
 
 pub struct TreeNodeWidget {
-    is_expanded: bool,
+    is_expanded: Dynamic<bool>,
     child: WidgetRef,
     child_height: Option<Px>,
+}
+
+impl TreeNodeWidget {
+    pub fn new(child: impl MakeWidget) -> Self {
+
+        let is_expanded = Dynamic::new(true);
+
+        let indicator = is_expanded.map_each(|value|{
+            match value {
+                true => "v",
+                false => ">"
+            }
+        }).into_label();
+
+        let expand_button = indicator.into_button()
+            .on_click({
+                let is_expanded = is_expanded.clone();
+                move |_event| {
+                    is_expanded.toggle();
+                }
+            })
+            .make_widget();
+
+        let child = expand_button.and(child).into_columns().into_ref();
+
+        Self {
+            is_expanded,
+            child,
+            child_height: None,
+        }
+    }
 }
 
 impl Debug for TreeNode {
@@ -70,7 +102,6 @@ impl Tree {
 
     /// Inserts a child after the given parent
     pub fn insert_child(&mut self, value: impl MakeWidget, parent: Option<&TreeNodeKey>) -> Option<TreeNodeKey> {
-        let child = value.into_ref();
 
         // Determine whether a new key and node should be created
         let (depth, parent_clone) = {
@@ -91,11 +122,7 @@ impl Tree {
         if let Some(depth) = depth {
             let key = self.generate_next_key(); // Generate key after deciding a node is needed
 
-            let child_widget = TreeNodeWidget {
-                is_expanded: true,
-                child,
-                child_height: None,
-            }.make_widget();
+            let child_widget = TreeNodeWidget::new(value).make_widget();
 
             let child_node = TreeNode {
                 parent: parent_clone,
@@ -115,7 +142,6 @@ impl Tree {
     ///
     /// Returns `None` if the given node doesn't exist.
     pub fn insert_after(&mut self, value: impl MakeWidget, sibling: &TreeNodeKey) -> Option<TreeNodeKey> {
-        let child = value.into_ref();
 
         // Determine whether a new key and node should be created
         let (depth, parent) = {
@@ -129,11 +155,7 @@ impl Tree {
         if let Some(depth) = depth {
             let key = self.generate_next_key(); // Generate key after deciding a node is needed
 
-            let child_widget = TreeNodeWidget {
-                is_expanded: true,
-                child,
-                child_height: None,
-            }.make_widget();
+            let child_widget = TreeNodeWidget::new(value).make_widget();
 
             let child_node = TreeNode {
                 parent,
@@ -341,7 +363,7 @@ impl WrapperWidget for TreeNodeWidget {
             self.child_height.replace(size.height);
         }
 
-        let size = match self.is_expanded {
+        let size = match self.is_expanded.get_tracking_invalidate(_context) {
             true => Size::new(size.width, self.child_height.unwrap()),
             false => Size::new(size.width, Px::new(0)),
         };

--- a/src/widgets/tree.rs
+++ b/src/widgets/tree.rs
@@ -5,7 +5,7 @@ use cushy::widget::{MakeWidget, WidgetRef, WrapperWidget};
 use cushy::widgets::Space;
 use indexmap::IndexMap;
 use crate::value::{Destination, Dynamic, Source, Switchable};
-use crate::widget::{IntoWidgetList, WidgetInstance};
+use crate::widget::{IntoWidgetList, MakeWidgetList, WidgetInstance, WidgetList};
 use crate::widgets::label::Displayable;
 
 #[derive(Default,Clone, Debug, Hash, PartialEq, Eq)]
@@ -15,6 +15,7 @@ pub struct TreeNode {
     parent: Option<TreeNodeKey>,
     depth: usize,
     child_widget: WidgetInstance,
+    children: Dynamic<WidgetList>,
 }
 
 pub struct TreeNodeWidget {
@@ -24,7 +25,7 @@ pub struct TreeNodeWidget {
 }
 
 impl TreeNodeWidget {
-    pub fn new(tree: &Tree, key: TreeNodeKey, child: impl MakeWidget) -> Self {
+    pub fn new(child: impl MakeWidget, children: Dynamic<WidgetList>) -> Self {
 
         let is_expanded = Dynamic::new(true);
 
@@ -44,34 +45,10 @@ impl TreeNodeWidget {
             })
             .make_widget();
 
-        // FIXME the node will never have any children when this is called
-        //       is the only callers are the 'insert_...' methods, the tree needs to be dynamic
-        //       and the widget list be re-created when the children for the given key change.
-
-        let children = {
-            //let tree = tree.lock();
-            let children_keys = tree.children_keys(key);
-
-            let children: Vec<WidgetInstance> = children_keys.iter().map(|child_key|{
-
-                let child = tree.nodes.lock().get(child_key);
-
-                "some_child"
-                    .into_label()
-                    .make_widget()
-            }).collect();
-
-            children
-                .into_widget_list()
-                .into_rows()
-                .contain()
-                .make_widget()
-        };
-
         let child = expand_button
             .and(child)
             .into_columns()
-            .and(children)
+            .and(children.into_rows())
             .into_rows()
             // FIXME remove container, just for tree right now.
             .contain()
@@ -118,7 +95,7 @@ impl Default for Tree {
         Self {
             nodes,
             next_key: TreeNodeKey::default(),
-            root
+            root,
         }
     }
 }
@@ -133,7 +110,7 @@ impl Tree {
     pub fn insert_child(&mut self, value: impl MakeWidget, parent: Option<&TreeNodeKey>) -> Option<TreeNodeKey> {
 
         // Determine whether a new key and node should be created
-        let (depth, parent_clone) = {
+        let (depth, parent_key) = {
             let nodes = self.nodes.lock();
             if let Some(parent) = parent {
                 if let Some(parent_node) = nodes.get(parent) {
@@ -151,19 +128,50 @@ impl Tree {
         if let Some(depth) = depth {
             let key = self.generate_next_key(); // Generate key after deciding a node is needed
 
-            let child_widget = TreeNodeWidget::new(self, key.clone(), value).make_widget();
+            let children = Dynamic::new(WidgetList::new());
+            let child_widget = TreeNodeWidget::new(value, children.clone()).make_widget();
 
             let child_node = TreeNode {
-                parent: parent_clone,
+                parent: parent_key.clone(),
                 depth,
                 child_widget,
+                children,
             };
 
-            let mut nodes = self.nodes.lock();
-            nodes.insert(key.clone(), child_node);
+            {
+                let mut nodes = self.nodes.lock();
+                nodes.insert(key.clone(), child_node);
+            }
+
+            self.update_children_widgetlist(parent_key);
+
             Some(key)
         } else {
             None
+        }
+    }
+
+    fn update_children_widgetlist(&mut self, parent_key: Option<TreeNodeKey>) {
+        if let Some(parent_key) = parent_key {
+            // regenerate the 'children' widget list for the parent
+
+            let children: WidgetList = self.children_keys(parent_key.clone())
+                .into_iter()
+                .enumerate()
+                .map(|(index, key)| {
+                    let nodes = self.nodes.lock();
+                    let node = nodes.get(&key).unwrap();
+
+                    index.into_label().make_widget()
+                        .and(node.child_widget.clone())
+                        .into_columns()
+                        .make_widget()
+                })
+                .collect();
+
+            let mut nodes = self.nodes.lock();
+            let parent = nodes.get(&parent_key).unwrap();
+            parent.children.set(children);
         }
     }
 
@@ -173,7 +181,7 @@ impl Tree {
     pub fn insert_after(&mut self, value: impl MakeWidget, sibling: &TreeNodeKey) -> Option<TreeNodeKey> {
 
         // Determine whether a new key and node should be created
-        let (depth, parent) = {
+        let (depth, parent_key) = {
             let nodes = self.nodes.lock();
             nodes.get(sibling).map_or((None, None), |node|{
                 (Some(node.depth), Some(node.parent.clone().unwrap()))
@@ -184,16 +192,23 @@ impl Tree {
         if let Some(depth) = depth {
             let key = self.generate_next_key(); // Generate key after deciding a node is needed
 
-            let child_widget = TreeNodeWidget::new(self, key.clone(), value).make_widget();
+            let children = Dynamic::new(WidgetList::new());
+            let child_widget = TreeNodeWidget::new(value, children.clone()).make_widget();
 
             let child_node = TreeNode {
-                parent,
+                parent: parent_key.clone(),
                 depth,
                 child_widget,
+                children
             };
 
-            let mut nodes = self.nodes.lock();
-            nodes.insert(key.clone(), child_node);
+            {
+                let mut nodes = self.nodes.lock();
+                nodes.insert(key.clone(), child_node);
+            }
+
+            self.update_children_widgetlist(parent_key);
+
             Some(key)
         } else {
             None

--- a/src/widgets/tree.rs
+++ b/src/widgets/tree.rs
@@ -1,10 +1,11 @@
 use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
 use cushy::figures::units::Px;
 use cushy::widget::{MakeWidget, WidgetRef, WrapperWidget};
 use cushy::widgets::Space;
 use indexmap::IndexMap;
 use crate::value::{Destination, Dynamic, Source, Switchable};
-use crate::widget::WidgetInstance;
+use crate::widget::{IntoWidgetList, WidgetInstance};
 use crate::widgets::label::Displayable;
 
 #[derive(Default,Clone, Debug, Hash, PartialEq, Eq)]
@@ -23,7 +24,7 @@ pub struct TreeNodeWidget {
 }
 
 impl TreeNodeWidget {
-    pub fn new(child: impl MakeWidget) -> Self {
+    pub fn new(tree: &Tree, key: TreeNodeKey, child: impl MakeWidget) -> Self {
 
         let is_expanded = Dynamic::new(true);
 
@@ -43,9 +44,35 @@ impl TreeNodeWidget {
             })
             .make_widget();
 
+        // FIXME the node will never have any children when this is called
+        //       is the only callers are the 'insert_...' methods, the tree needs to be dynamic
+        //       and the widget list be re-created when the children for the given key change.
+
+        let children = {
+            //let tree = tree.lock();
+            let children_keys = tree.children_keys(key);
+
+            let children: Vec<WidgetInstance> = children_keys.iter().map(|child_key|{
+
+                let child = tree.nodes.lock().get(child_key);
+
+                "some_child"
+                    .into_label()
+                    .make_widget()
+            }).collect();
+
+            children
+                .into_widget_list()
+                .into_rows()
+                .contain()
+                .make_widget()
+        };
+
         let child = expand_button
             .and(child)
             .into_columns()
+            .and(children)
+            .into_rows()
             // FIXME remove container, just for tree right now.
             .contain()
             .into_ref();
@@ -67,7 +94,7 @@ impl Debug for TreeNode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Tree {
     nodes: Dynamic<IndexMap<TreeNodeKey, TreeNode>>,
     next_key: TreeNodeKey,
@@ -124,7 +151,7 @@ impl Tree {
         if let Some(depth) = depth {
             let key = self.generate_next_key(); // Generate key after deciding a node is needed
 
-            let child_widget = TreeNodeWidget::new(value).make_widget();
+            let child_widget = TreeNodeWidget::new(self, key.clone(), value).make_widget();
 
             let child_node = TreeNode {
                 parent: parent_clone,
@@ -157,7 +184,7 @@ impl Tree {
         if let Some(depth) = depth {
             let key = self.generate_next_key(); // Generate key after deciding a node is needed
 
-            let child_widget = TreeNodeWidget::new(value).make_widget();
+            let child_widget = TreeNodeWidget::new(self, key.clone(), value).make_widget();
 
             let child_node = TreeNode {
                 parent,
@@ -200,6 +227,19 @@ impl Tree {
                     .for_each(|key| to_remove.push(key.clone()));
             }
         }
+    }
+
+    pub fn children_keys(&self, parent_key: TreeNodeKey) -> Vec<TreeNodeKey> {
+        let nodes = self.nodes.lock();
+        nodes.iter()
+            .filter_map(|(key, node)| {
+                if node.parent.as_ref() == Some(&parent_key) {
+                    Some(key.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 }
 
@@ -342,6 +382,23 @@ mod tests {
         // and child and children should be removed
         assert!(nodes.get(&key_1).is_none());
         assert!(nodes.get(&key_3).is_none());
+    }
+
+    #[test]
+    pub fn children_keys() {
+        // given
+        let mut tree = Tree::default();
+        let root_key = tree.insert_child("root".to_string(), None).unwrap();
+        let child_key_1 = tree.insert_child("child_1".to_string(), Some(&root_key)).unwrap();
+        let child_key_2 = tree.insert_child("child_2".to_string(), Some(&root_key)).unwrap();
+
+        // when
+        let children = tree.children_keys(root_key.clone());
+
+        // then
+        assert_eq!(children.len(), 2);
+        assert!(children.contains(&child_key_1));
+        assert!(children.contains(&child_key_2));
     }
 }
 

--- a/src/widgets/tree.rs
+++ b/src/widgets/tree.rs
@@ -1,9 +1,6 @@
 use std::fmt::{Debug, Formatter};
-use cushy::ConstraintLimit;
-use cushy::context::LayoutContext;
-use cushy::figures::Size;
 use cushy::figures::units::Px;
-use cushy::widget::{MakeWidget, WidgetRef, WrappedLayout, WrapperWidget};
+use cushy::widget::{MakeWidget, WidgetRef, WrapperWidget};
 use cushy::widgets::Space;
 use indexmap::IndexMap;
 use crate::value::{Destination, Dynamic, Source, Switchable};
@@ -356,19 +353,6 @@ impl Debug for TreeNodeWidget {
 impl WrapperWidget for TreeNodeWidget {
     fn child_mut(&mut self) -> &mut WidgetRef {
         &mut self.child
-    }
-
-    fn position_child(&mut self, size: Size<Px>, _available_space: Size<ConstraintLimit>, _context: &mut LayoutContext<'_, '_, '_, '_>) -> WrappedLayout {
-        if self.child_height.is_none() {
-            self.child_height.replace(size.height);
-        }
-
-        let size = match self.is_expanded.get_tracking_invalidate(_context) {
-            true => Size::new(size.width, self.child_height.unwrap()),
-            false => Size::new(size.width, Px::new(0)),
-        };
-
-        size.into()
     }
 }
 


### PR DESCRIPTION
First attempt add adding a dynamic tree widget.

Features:
* nodes are widgets.
* nodes can be expanded/collapsed.
* tree can be accessed and manipulated from within the node widgets, e.g. by 'Button::on_click'.

![image](https://github.com/user-attachments/assets/73ea70b8-a0fd-4021-8ebd-8d920ac446d2)

TODO
* [ ] Make performant.
* [ ] Use icons instead of `>` and `v`.
* [ ] Remove use of the `.contain()` which is currently there for visualization/debugging purposes.
* [ ] Document.
* [ ] Cleanup code.
* [ ] Squash or cleanup commits.

Issues:
* the performance is currently abysmal once you add around 4 nested children. adding another child using the 'Add child' makes the UI stall for longer and longer periods for each nested child, scrolling becomes very slow.

Notes:
* No idea if the approach I took, of using widget composition, was a good idea.
* Probably some unneeded code, as I tried various approaches that didn't work until I stumbled on one that does.
* Probably there's some unnecessary cloning going on too, maybe on the whole tree itself including all the nodes.
