### PR TITLE
Fix compilation error 1.

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 
 use figures::units::{Px, UPx};
 use figures::{
-    self, Fraction, IntoSigned, IntoUnsigned, Point, Rect, ScreenScale, ScreenUnit, Size, Zero,
+    self, Fraction, IntoSigned, IntoUnsigned, Point, Rect, Round, ScreenScale, ScreenUnit, Size, Zero
 };
 use kempt::{map, Map};
 use kludgine::cosmic_text::{fontdb, FamilyOwned, FontSystem};
@@ -285,7 +285,7 @@ impl<'clip, 'gfx, 'pass> Graphics<'clip, 'gfx, 'pass> {
         text: impl Into<Drawable<&'a MeasuredText<Unit>, Unit>>,
         origin: TextOrigin<Unit>,
     ) where
-        Unit: ScreenUnit,
+        Unit: ScreenUnit + Round,
     {
         let mut text = text.into();
         text.opacity = Some(


### PR DESCRIPTION
As reported a couple of times in discord:
1. https://discord.com/channels/578968877866811403/842093272540643339/1314507996105146378
2. https://discord.com/channels/578968877866811403/842093272540643339/1314558272325423105

```
error[E0277]: the trait bound `Unit: figures::Round` is not satisfied
   --> C:\Users\mpepo\.cargo\git\checkouts\cushy-4f32554903a9355c\4ba6154\src\graphics.rs:296:48
    |
296 |         self.renderer.draw_measured_text(text, origin);
    |                       ------------------       ^^^^^^ the trait `figures::Round` is not implemented for `Unit`
    |                       |
    |                       required by a bound introduced by this call
    |
note: required by a bound in `drawing::text::<impl Renderer<'_, 'gfx>>::draw_measured_text
```