### PR TITLE
Pile - Improve API by avoiding boolean arguments on the `show` method.

### DIFF
--- a/examples/pile.rs
+++ b/examples/pile.rs
@@ -1,7 +1,7 @@
 use cushy::value::Dynamic;
 use cushy::widget::{MakeWidget, WidgetList};
 use cushy::widgets::input::InputValue;
-use cushy::widgets::pile::Pile;
+use cushy::widgets::pile::{Focus, Pile};
 use cushy::Run;
 
 fn main() -> cushy::Result {
@@ -20,7 +20,7 @@ fn main() -> cushy::Result {
                 .into_button()
                 .on_click({
                     let section = handle.clone();
-                    move |_| section.show(true)
+                    move |_| section.show(Focus::Unchanged)
                 })
                 .make_widget();
             let button_id = button.id();

--- a/examples/pile.rs
+++ b/examples/pile.rs
@@ -1,7 +1,7 @@
 use cushy::value::Dynamic;
 use cushy::widget::{MakeWidget, WidgetList};
 use cushy::widgets::input::InputValue;
-use cushy::widgets::pile::{Focus, Pile};
+use cushy::widgets::pile::Pile;
 use cushy::Run;
 
 fn main() -> cushy::Result {
@@ -20,7 +20,7 @@ fn main() -> cushy::Result {
                 .into_button()
                 .on_click({
                     let section = handle.clone();
-                    move |_| section.show(Focus::Unchanged)
+                    move |_| section.show_and_focus()
                 })
                 .make_widget();
             let button_id = button.id();

--- a/src/widgets/pile.rs
+++ b/src/widgets/pile.rs
@@ -26,10 +26,17 @@ pub struct Pile {
 }
 
 #[derive(Default, Debug)]
+pub enum Focus {
+    Focused,
+    #[default]
+    Unchanged
+}
+
+#[derive(Default, Debug)]
 struct PileData {
     widgets: Lots<Option<WidgetInstance>>,
     visible: VecDeque<LotId>,
-    focus_visible: bool,
+    focus_visible: Focus,
 }
 
 impl PileData {
@@ -122,7 +129,7 @@ impl Widget for WidgetPile {
                 .expect("visible widget")
                 .mounted(context);
             let mut child_context = context.for_other(&visible);
-            if pile.focus_visible && self.last_visible != Some(id) {
+            if matches!(pile.focus_visible, Focus::Focused) && self.last_visible != Some(id) {
                 child_context.focus();
             }
             let size = child_context.layout(available_space);
@@ -192,7 +199,7 @@ impl PiledWidget {
     /// Shows this widget in its pile.
     ///
     /// If `focus` is true, the widget will be focused when shown.
-    pub fn show(&self, focus: bool) {
+    pub fn show(&self, focus: Focus) {
         let mut pile = self.0.pile.data.lock();
         pile.hide_id(self.0.id);
         pile.visible.push_front(self.0.id);
@@ -203,7 +210,7 @@ impl PiledWidget {
     pub fn remove(&self) {
         let mut pile = self.0.pile.data.lock();
         if pile.visible.front() == Some(&self.0.id) {
-            pile.focus_visible = false;
+            pile.focus_visible = Focus::Unchanged;
         }
         pile.hide_id(self.0.id);
         pile.widgets.remove(self.0.id);


### PR DESCRIPTION

Rationale:

Given:
```rust
handle.show(true)
```
The reader is forced to look at the documentation or the code for the `show` method and leaves the reader wondering what the boolean argument will do.

Conversely:
```rust
handle.show(Focus::Focused)
```
The code is unambiguous.
