### PR TITLE
Add a Channel-like type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   application to create deadlocks with relatively simple data flows like the new
   `7guis-timer` example.
 - The type `cushy::Graphics` is now available at `cushy::graphics::Graphics`.
+- `Source::for_each_cloned_*` now invoke the callback with the current contents
+  of of the source before attaching the callback. New functions beginning with
+  `for_each_subsequent_cloned` have been added with the original behavior. This
+  change was done to make `for_each_cloned` and `for_each` have the same
+  semantics.
 
 ### Changed
 

--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -34,7 +34,7 @@ fn main() -> cushy::Result {
         clicking the button quickly and seeing how the \
         channel version increments for every click while \
         the dynamic version increments at most once every \
-        500 milliseconds."
+        second."
         .and(
             "Click Me"
                 .into_button()

--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -1,0 +1,58 @@
+use std::time::{Duration, Instant};
+
+use cushy::value::{Destination, Dynamic, Source};
+use cushy::widget::MakeWidget;
+use cushy::widgets::label::Displayable;
+use cushy::Run;
+
+fn main() -> cushy::Result {
+    let channel_counter = Dynamic::new(0_usize);
+    let channel_counter_label = channel_counter.to_label();
+    let sender = cushy::channel::build()
+        .on_receive({
+            move |_| {
+                std::thread::sleep(Duration::from_secs(1));
+                *channel_counter.lock() += 1;
+            }
+        })
+        .finish();
+
+    let dynamic_counter = Dynamic::new(0_usize);
+    let dynamic_counter_label = dynamic_counter.to_label();
+    let dynamic_value = Dynamic::new(Instant::now());
+    // We use a `for_each_subsequent_cloned` to only execute the callback after
+    // the current value changes, and the `cloned` version ensures the dynamic
+    // isn't locked while the callback is being executed.
+    dynamic_value
+        .for_each_subsequent_cloned(move |_| {
+            std::thread::sleep(Duration::from_secs(1));
+            *dynamic_counter.lock() += 1;
+        })
+        .persist();
+
+    "Channels ensure every value sent is received. Try \
+        clicking the button quickly and seeing how the \
+        channel version increments for every click while \
+        the dynamic version increments at most once every \
+        500 milliseconds."
+        .and(
+            "Click Me"
+                .into_button()
+                .on_click(move |_| {
+                    let now = Instant::now();
+                    sender.send(now).expect("value to be received");
+                    dynamic_value.set(now);
+                })
+                .centered(),
+        )
+        .and(
+            "Channel Counter"
+                .and(channel_counter_label)
+                .into_rows()
+                .and("Dynamic Counter".and(dynamic_counter_label).into_rows())
+                .into_columns()
+                .centered(),
+        )
+        .into_rows()
+        .run()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,12 @@ mod names;
 #[macro_use]
 pub mod styles;
 mod app;
+mod reactive;
+pub use reactive::{channel, value};
 pub mod debug;
 pub mod fonts;
 mod tick;
 mod tree;
-pub mod value;
 pub mod widget;
 pub mod widgets;
 pub mod window;

--- a/src/reactive.rs
+++ b/src/reactive.rs
@@ -1,0 +1,641 @@
+use std::cell::Cell;
+use std::collections::{hash_map, VecDeque};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{mpsc, Arc};
+use std::task::{Context, Poll, Wake, Waker};
+use std::time::Instant;
+
+use ahash::AHashMap;
+use alot::{LotId, Lots};
+use kempt::{map, Map, Set};
+use parking_lot::Mutex;
+use tracing::warn;
+
+use self::channel::{AnyChannel, ChannelCallbackFuture};
+use self::value::{CallbackDisconnected, DeadlockError, DynamicLockData};
+use crate::Lazy;
+
+pub mod channel;
+pub mod value;
+
+static CALLBACK_EXECUTORS: Mutex<Map<usize, Arc<DynamicLockData>>> = Mutex::new(Map::new());
+
+fn execute_callbacks(
+    lock: Arc<DynamicLockData>,
+    callbacks: &mut CallbacksList,
+) -> Result<usize, DeadlockError> {
+    let mut executors = CALLBACK_EXECUTORS.lock();
+    let key = Arc::as_ptr(&lock) as usize;
+    match executors.entry(key) {
+        map::Entry::Occupied(_) => return Err(DeadlockError),
+        map::Entry::Vacant(entry) => {
+            entry.insert(lock);
+        }
+    }
+    drop(executors);
+
+    // Invoke all callbacks, removing those that report an
+    // error.
+    let mut count = 0;
+    callbacks.invoked_at = Instant::now();
+    callbacks.callbacks.drain_filter(|callback| {
+        count += 1;
+        callback.changed().is_err()
+    });
+
+    let mut executors = CALLBACK_EXECUTORS.lock();
+    executors.remove(&key);
+
+    Ok(count)
+}
+
+trait CallbackCollection: Send + Sync + 'static {
+    fn remove(&self, id: LotId);
+}
+
+#[derive(Default)]
+struct ChangeCallbacksData {
+    callbacks: Mutex<CallbacksList>,
+    lock: Arc<DynamicLockData>,
+}
+
+impl CallbackCollection for ChangeCallbacksData {
+    fn remove(&self, id: LotId) {
+        if CallbackExecutor::is_current_thread() {
+            let mut state = self.lock.state.lock();
+            state.callbacks_to_remove.push(id);
+        } else {
+            let mut data = self.callbacks.lock();
+            data.callbacks.remove(id);
+        }
+    }
+}
+
+struct CallbacksList {
+    callbacks: Lots<Box<dyn ValueCallback>>,
+    invoked_at: Instant,
+}
+
+impl Default for CallbacksList {
+    fn default() -> Self {
+        Self {
+            callbacks: Lots::new(),
+            invoked_at: Instant::now(),
+        }
+    }
+}
+
+struct ChangeCallbacks {
+    data: Arc<ChangeCallbacksData>,
+    changed_at: Instant,
+}
+
+impl ChangeCallbacks {
+    fn new(data: Arc<ChangeCallbacksData>) -> Self {
+        Self {
+            data,
+            changed_at: Instant::now(),
+        }
+    }
+
+    fn execute(self) -> usize {
+        // Invoke the callbacks
+        let mut data = self.data.callbacks.lock();
+        // If the callbacks have already been invoked by another
+        // thread such that the callbacks observed the value our
+        // thread wrote, we can skip the callbacks.
+        let Some(Ok(count)) = (data.invoked_at < self.changed_at)
+            .then(|| execute_callbacks(self.data.lock.clone(), &mut data))
+        else {
+            return 0;
+        };
+
+        // Clean up all callbacks that were disconnected while our callbacks
+        // were locked.
+        let mut state = self.data.lock.state.lock();
+        for callback in state.callbacks_to_remove.drain(..) {
+            data.callbacks.remove(callback);
+        }
+        drop(data);
+        drop(state);
+        self.data.lock.sync.notify_all();
+        count
+    }
+
+    fn id(&self) -> CallbacksId {
+        CallbacksId(Arc::as_ptr(&self.data) as usize)
+    }
+}
+
+trait ValueCallback: Send {
+    fn changed(&mut self) -> Result<(), CallbackDisconnected>;
+}
+
+impl<F> ValueCallback for F
+where
+    F: for<'a> FnMut() -> Result<(), CallbackDisconnected> + Send + 'static,
+{
+    fn changed(&mut self) -> Result<(), CallbackDisconnected> {
+        self()
+    }
+}
+
+static THREAD_SENDER: Lazy<mpsc::SyncSender<BackgroundTask>> = Lazy::new(|| {
+    let (sender, receiver) = mpsc::sync_channel(256);
+    std::thread::spawn(move || CallbackExecutor::new(receiver).run());
+    sender
+});
+
+fn defer_execute_callbacks(callbacks: ChangeCallbacks) {
+    let invoked_by = EXECUTING_CALLBACK_ROOT.get();
+    let _ = THREAD_SENDER.send(BackgroundTask::ExecuteCallbacks {
+        callbacks,
+        invoked_by,
+    });
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+struct CallbacksId(usize);
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct CallbackInvocationId {
+    node: LotId,
+    invocation_root: CallbacksId,
+}
+
+struct InvocationTreeNode {
+    id: CallbacksId,
+    enqueued: Option<ChangeCallbacks>,
+    parent: Option<LotId>,
+    first_child: Option<LotId>,
+    root_callbacks: CallbacksId,
+    next: Option<LotId>,
+}
+
+#[derive(Default)]
+struct InvocationTree {
+    nodes: Lots<InvocationTreeNode>,
+}
+
+impl InvocationTree {
+    fn new_root(&mut self, callbacks: ChangeCallbacks) -> CallbackInvocationId {
+        let callbacks_id = callbacks.id();
+        let node = self.nodes.push(InvocationTreeNode {
+            id: callbacks_id,
+            parent: None,
+            first_child: None,
+            root_callbacks: callbacks_id,
+            enqueued: Some(callbacks),
+            next: None,
+        });
+        CallbackInvocationId {
+            node,
+            invocation_root: callbacks_id,
+        }
+    }
+
+    /// Pushes `invoked` into the list of callbacks executed by group of
+    /// callbacks pointed to by `invoked_by`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `invoked` has already been executed by this group of
+    /// callbacks.
+    fn push(
+        &mut self,
+        callbacks: ChangeCallbacks,
+        enqueued_while_executing: Option<CallbackInvocationId>,
+    ) -> Option<CallbackInvocationId> {
+        if let Some(enqueued_while_executing) = enqueued_while_executing {
+            // Verify that `callbacks` wasn't executed in the chain leading to the node that was executing this node.
+            let mut search = enqueued_while_executing.node;
+            let callbacks_id = callbacks.id();
+            loop {
+                let node = &self.nodes[search];
+                if node.id == callbacks_id {
+                    // This set of callbacks has already been executed in this
+                    // chain.
+                    return None;
+                }
+                let Some(parent) = node.parent else {
+                    break;
+                };
+                search = parent;
+            }
+            let root_invoked_by = enqueued_while_executing.invocation_root;
+            let existing_first_child = self.nodes[enqueued_while_executing.node].first_child;
+            if let Some(mut node_id) = existing_first_child {
+                loop {
+                    let node = &mut self.nodes[node_id];
+                    if node.id == callbacks_id {
+                        if let Some(enqueued) = &mut node.enqueued {
+                            enqueued.changed_at = enqueued.changed_at.max(callbacks.changed_at);
+                            return None;
+                        }
+
+                        node.enqueued = Some(callbacks);
+                        return Some(CallbackInvocationId {
+                            node: node_id,
+                            invocation_root: root_invoked_by,
+                        });
+                    }
+
+                    if let Some(next) = node.next {
+                        // Continue traversing the list.
+                        node_id = next;
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            // `callbacks` hasn't been executed by the list pointed at by
+            // `enqueued_while_executing`.
+            let id = self.nodes.push(InvocationTreeNode {
+                id: callbacks.id(),
+                enqueued: Some(callbacks),
+                parent: Some(enqueued_while_executing.node),
+                first_child: None,
+                root_callbacks: root_invoked_by,
+                next: existing_first_child,
+            });
+            self.nodes[enqueued_while_executing.node].first_child = Some(id);
+            Some(CallbackInvocationId {
+                node: id,
+                invocation_root: root_invoked_by,
+            })
+        } else {
+            // New root
+            Some(self.new_root(callbacks))
+        }
+    }
+
+    fn complete(&mut self, invocation: CallbackInvocationId) {
+        self.remove_completed_recursive(invocation.node);
+    }
+
+    fn remove_completed_recursive(&mut self, mut node_id: LotId) {
+        let mut node = &mut self.nodes[node_id];
+        while node.enqueued.is_none() && node.first_child.is_none() {
+            let after_removed = node.next;
+            if let Some(parent_id) = node.parent {
+                let parent = &mut self.nodes[parent_id];
+                // Repair the linked list
+                if parent.first_child == Some(node_id) {
+                    parent.first_child = after_removed;
+                } else {
+                    let mut current = parent.first_child.expect("valid child");
+                    while self.nodes[current].next != Some(node_id) {
+                        current = self.nodes[current].next.expect("removed node to exist");
+                    }
+                    self.nodes[current].next = after_removed;
+                }
+
+                self.nodes.remove(node_id);
+
+                // Attempt to remove the parent if this was its last node.
+                node = &mut self.nodes[parent_id];
+                node_id = parent_id;
+            } else {
+                self.nodes.remove(node_id);
+                break;
+            }
+        }
+    }
+}
+
+thread_local! {
+    static EXECUTING_CALLBACK_ROOT: Cell<Option<CallbackInvocationId>> = const { Cell::new(None) };
+}
+
+struct EnqueuedCallbacks {
+    node_id: CallbackInvocationId,
+    callbacks: ChangeCallbacks,
+}
+
+enum BackgroundTask {
+    ExecuteCallbacks {
+        callbacks: ChangeCallbacks,
+        invoked_by: Option<CallbackInvocationId>,
+    },
+    Channel(ChannelTask),
+    Wake(usize),
+}
+
+enum ChannelTask {
+    Register {
+        id: usize,
+        data: Arc<dyn AnyChannel>,
+    },
+    Notify {
+        id: usize,
+    },
+    Unregister(usize),
+}
+
+struct RegisteredFuture {
+    future: Option<PollChannelFuture>,
+    waker: Waker,
+}
+
+struct FutureWaker {
+    id: usize,
+}
+
+impl Wake for FutureWaker {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        let _ = THREAD_SENDER.send(BackgroundTask::Wake(self.id));
+    }
+}
+
+#[derive(Default)]
+struct Futures {
+    registered: Vec<RegisteredFuture>,
+    queue: VecDeque<usize>,
+    available: Set<usize>,
+}
+
+impl Futures {
+    fn push(&mut self, future: PollChannelFuture) -> usize {
+        let mut id = None;
+        while !self.available.is_empty() {
+            let available_id = self.available.remove_member(0);
+            if self.registered[available_id].future.is_none() {
+                id = Some(available_id);
+                break;
+            }
+        }
+        if let Some(id) = id {
+            self.registered[id].future = Some(future);
+            id
+        } else {
+            let id = self.registered.len();
+            self.registered.push(RegisteredFuture {
+                future: Some(future),
+                waker: Waker::from(Arc::new(FutureWaker { id })),
+            });
+            id
+        }
+    }
+
+    fn poll(&mut self) -> usize {
+        // We want to make sure we yield to allow other change callbacks to
+        // execute, so we only allow each future currently enqueued to be polled
+        // once.
+        let mut callbacks_executed = 0;
+        for _ in 0..self.queue.len() {
+            let Some(id) = self.queue.pop_front() else {
+                break;
+            };
+
+            let registered = &mut self.registered[id];
+            if let Some(future) = &mut registered.future {
+                let mut ctx = Context::from_waker(&registered.waker);
+                match Pin::new(future).poll(&mut ctx) {
+                    Poll::Ready(()) => {
+                        self.registered.remove(id);
+                        callbacks_executed += 1;
+                    }
+                    Poll::Pending => {}
+                }
+            } else {
+                self.available.insert(id);
+            }
+        }
+        callbacks_executed
+    }
+
+    fn wake(&mut self, id: usize) {
+        self.queue.push_back(id);
+    }
+}
+
+struct CallbackExecutor {
+    receiver: mpsc::Receiver<BackgroundTask>,
+
+    channels: WatchedChannels,
+    futures: Futures,
+
+    invocations: InvocationTree,
+    queue: VecDeque<LotId>,
+}
+
+impl CallbackExecutor {
+    fn new(receiver: mpsc::Receiver<BackgroundTask>) -> Self {
+        Self {
+            receiver,
+            invocations: InvocationTree::default(),
+            queue: VecDeque::new(),
+            futures: Futures::default(),
+            channels: WatchedChannels::default(),
+        }
+    }
+
+    fn enqueue_nonblocking(&mut self) {
+        // Exhaust any pending callbacks without blocking.
+        while let Ok(task) = self.receiver.try_recv() {
+            self.enqueue(task);
+        }
+    }
+
+    fn run(mut self) {
+        IS_EXECUTOR_THREAD.set(true);
+
+        // Because this is stored in a static, this likely will never return an
+        // error, but if it does, it's during program shutdown, and we can exit safely.
+        while let Ok(task) = self.receiver.recv() {
+            self.enqueue(task);
+
+            loop {
+                let mut callbacks_executed = 0;
+                loop {
+                    let Some(enqueued) = self.pop_callbacks() else {
+                        break;
+                    };
+                    EXECUTING_CALLBACK_ROOT.set(Some(enqueued.node_id));
+                    callbacks_executed += enqueued.callbacks.execute();
+
+                    // Enqueue any queued operations before we complete this
+                    // invocation to ensure all related invocations are tracked.
+                    self.enqueue_nonblocking();
+                    self.invocations.complete(enqueued.node_id);
+                }
+                EXECUTING_CALLBACK_ROOT.set(None);
+
+                // Once we've exited the loop, we can assume all callback invocation
+                // chains have completed.
+                assert!(self.invocations.nodes.is_empty());
+
+                callbacks_executed += self.futures.poll();
+
+                if callbacks_executed > 0 {
+                    tracing::trace!("{callbacks_executed} callbacks executed");
+                }
+
+                if self.futures.queue.is_empty() {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn enqueue(&mut self, task: BackgroundTask) {
+        match task {
+            BackgroundTask::Channel(channel) => match channel {
+                ChannelTask::Register { id, data } => {
+                    self.channels.register(id, data, &mut self.futures);
+                }
+                ChannelTask::Notify { id } => {
+                    self.channels.notify(id, &mut self.futures);
+                }
+                ChannelTask::Unregister(id) => {
+                    self.channels.unregister(id);
+                }
+            },
+            BackgroundTask::ExecuteCallbacks {
+                callbacks,
+                invoked_by,
+            } => {
+                if let Some(pushed) = self.invocations.push(callbacks, invoked_by) {
+                    self.queue.push_back(pushed.node);
+                }
+            }
+            BackgroundTask::Wake(future_id) => {
+                self.futures.wake(future_id);
+            }
+        }
+    }
+
+    fn pop_callbacks(&mut self) -> Option<EnqueuedCallbacks> {
+        while let Some(id) = self.queue.pop_front() {
+            if let Some(callbacks) = self.invocations.nodes[id].enqueued.take() {
+                return Some(EnqueuedCallbacks {
+                    callbacks,
+                    node_id: CallbackInvocationId {
+                        node: id,
+                        invocation_root: self.invocations.nodes[id].root_callbacks,
+                    },
+                });
+            }
+        }
+
+        None
+    }
+
+    fn is_current_thread() -> bool {
+        IS_EXECUTOR_THREAD.get()
+    }
+}
+
+#[derive(Default)]
+struct WatchedChannels {
+    registry: Lots<WatchedChannel>,
+    by_id: AHashMap<usize, LotId>,
+}
+
+impl WatchedChannels {
+    fn register(&mut self, id: usize, channel: Arc<dyn AnyChannel>, futures: &mut Futures) {
+        let hash_map::Entry::Vacant(entry) = self.by_id.entry(id) else {
+            return;
+        };
+        let future_id = channel.should_poll().then(|| {
+            futures.push(PollChannelFuture {
+                channel: channel.clone(),
+                futures: Vec::new(),
+            })
+        });
+        entry.insert(self.registry.push(WatchedChannel {
+            data: channel,
+            future_id,
+        }));
+    }
+
+    fn notify(&mut self, id: usize, futures: &mut Futures) {
+        let Some(channel) = self
+            .by_id
+            .get(&id)
+            .and_then(|id| self.registry.get_mut(*id))
+        else {
+            return;
+        };
+        if channel.future_id.is_none() {
+            channel.future_id = Some(futures.push(PollChannelFuture {
+                channel: channel.data.clone(),
+                futures: Vec::new(),
+            }));
+        }
+        futures
+            .queue
+            .push_back(channel.future_id.expect("initialized above"));
+    }
+
+    fn unregister(&mut self, id: usize) {
+        let Some(id) = self.by_id.remove(&id) else {
+            return;
+        };
+        self.registry.remove(id);
+    }
+}
+
+struct WatchedChannel {
+    data: Arc<dyn AnyChannel>,
+    future_id: Option<usize>,
+}
+
+struct PollChannelFuture {
+    channel: Arc<dyn AnyChannel>,
+    futures: Vec<ChannelCallbackFuture>,
+}
+
+impl Future for PollChannelFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+        if this.futures.is_empty() && !this.channel.poll(&mut this.futures) {
+            return Poll::Ready(());
+        }
+        loop {
+            let mut completed_one = false;
+            let mut i = 0;
+            while i < self.futures.len() {
+                match self.futures[i].future.as_mut().poll(cx) {
+                    Poll::Ready(result) => {
+                        match result {
+                            Ok(()) => {}
+                            Err(CallbackDisconnected) => {
+                                self.channel.disconnect_callback();
+                            }
+                        }
+                        completed_one = true;
+                        self.futures.remove(i);
+                    }
+                    Poll::Pending => {
+                        i += 1;
+                    }
+                }
+            }
+
+            if !completed_one {
+                break;
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+thread_local! {
+    static IS_EXECUTOR_THREAD: Cell<bool> = const { Cell::new(false) };
+}
+
+fn enqueue_task(task: BackgroundTask) {
+    if THREAD_SENDER.send(task).is_err() {
+        warn!("background task thread not running");
+    }
+}

--- a/src/reactive/channel.rs
+++ b/src/reactive/channel.rs
@@ -899,22 +899,6 @@ where
         self.data.force_send_inner(value, channel_id(&self.data))
     }
 
-    /// Returns a [`Broadcaster`] that sends to this channel.
-    #[must_use]
-    pub fn create_broadcaster(&self) -> Broadcaster<T> {
-        let mut data = self.data.synced.lock();
-        data.senders += 1;
-        Broadcaster {
-            data: self.data.clone(),
-        }
-    }
-
-    /// Returns this instance as a [`Broadcaster`] that sends to this channel.
-    #[must_use]
-    pub fn into_broadcaster(self) -> Broadcaster<T> {
-        self.create_broadcaster()
-    }
-
     /// Invokes `on_receive` each time a value is sent to this channel.
     ///
     /// This function assumes `on_receive` may block while waiting on another
@@ -1036,6 +1020,24 @@ where
     }
 }
 
+impl<T> BroadcastChannel<T> {
+    /// Returns a [`Broadcaster`] that sends to this channel.
+    #[must_use]
+    pub fn create_broadcaster(&self) -> Broadcaster<T> {
+        let mut data = self.data.synced.lock();
+        data.senders += 1;
+        Broadcaster {
+            data: self.data.clone(),
+        }
+    }
+
+    /// Returns this instance as a [`Broadcaster`] that sends to this channel.
+    #[must_use]
+    pub fn into_broadcaster(self) -> Broadcaster<T> {
+        self.create_broadcaster()
+    }
+}
+
 impl<T> Clone for BroadcastChannel<T> {
     fn clone(&self) -> Self {
         let mut data = self.data.synced.lock();
@@ -1071,6 +1073,7 @@ impl<T> Drop for BroadcastChannel<T> {
 }
 
 /// Sends values to a [`BroadcastChannel`].
+#[derive(Debug)]
 pub struct Broadcaster<T> {
     data: Arc<ChannelData<T, MultipleCallbacks<T>>>,
 }

--- a/src/reactive/channel.rs
+++ b/src/reactive/channel.rs
@@ -1,0 +1,517 @@
+//! A reactive multi-sender, single-consumer (mpsc) channel for Cushy.
+
+use std::collections::VecDeque;
+use std::fmt::{self, Debug};
+use std::future::Future;
+use std::ops::ControlFlow;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
+
+use parking_lot::{Condvar, Mutex, MutexGuard};
+
+use crate::reactive::{enqueue_task, BackgroundTask, ChannelTask};
+use crate::value::CallbackDisconnected;
+
+/// An error occurred while trying to send a value.
+pub enum TrySendError<T> {
+    /// The recipient was full.
+    Full(T),
+    /// The recipient is no longer reachable.
+    Disconnected(T),
+}
+
+/// A future that sends a message to a [`Channel<T>`].
+#[must_use = "Futures must be awaited to be executed"]
+pub struct SendAsync<'a, T> {
+    value: Option<T>,
+    channel: &'a Channel<T>,
+}
+
+impl<T> Future for SendAsync<'_, T>
+where
+    T: Unpin + Clone + Send + 'static,
+{
+    type Output = Option<T>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let Some(value) = self.value.take() else {
+            return Poll::Ready(None);
+        };
+        match self.channel.try_send_inner(value, |channel| {
+            let will_wake = channel
+                .wakers
+                .iter()
+                .any(|waker| waker.will_wake(cx.waker()));
+            if !will_wake {
+                channel.wakers.push(cx.waker().clone());
+            }
+            ControlFlow::Break(())
+        }) {
+            Ok(()) => Poll::Ready(None),
+            Err(TrySendError::Disconnected(value)) => Poll::Ready(Some(value)),
+            Err(TrySendError::Full(value)) => {
+                self.value = Some(value);
+                Poll::Pending
+            }
+        }
+    }
+}
+
+pub(super) trait AnyChannel: Send + Sync + 'static {
+    fn should_poll(&self) -> bool;
+    fn poll(&self, futures: &mut Vec<ChannelCallbackFuture>) -> bool;
+    fn disconnect_callback(&self);
+}
+
+impl<T> AnyChannel for ChannelData<T>
+where
+    T: Send + 'static,
+{
+    fn should_poll(&self) -> bool {
+        let channel = self.synced.lock();
+        !channel.queue.is_empty() && channel.callback.is_some()
+    }
+
+    fn poll(&self, futures: &mut Vec<ChannelCallbackFuture>) -> bool {
+        let mut channel = self.synced.lock();
+
+        let Some(value) = channel.queue.pop_front() else {
+            return channel.instances > 0 && channel.callback.is_some();
+        };
+
+        self.condvar.notify_all();
+        for waker in channel.wakers.drain(..) {
+            waker.wake();
+        }
+
+        if let Some(callback) = &mut channel.callback {
+            match callback.invoke(value) {
+                Ok(()) => {}
+                Err(ChannelCallbackError::Async(future)) => {
+                    futures.push(ChannelCallbackFuture {
+                        future: Pin::from(future),
+                    });
+                }
+                Err(ChannelCallbackError::Disconnected) => {
+                    channel.callback = None;
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn disconnect_callback(&self) {
+        self.synced.lock().callback = None;
+    }
+}
+
+pub(super) struct ChannelCallbackFuture {
+    pub(super) future: Pin<Box<dyn Future<Output = Result<(), CallbackDisconnected>>>>,
+}
+
+/// A reactive multi-sender, single-consumer (mpsc) channel that executes code
+/// in the background when values are received.
+///
+/// A [`Dynamic<T>`](crate::value::Dynamic) is a container for a `T` that can be
+/// reacted against. Due to this design, it is possible to not observe *every*
+/// value that passes through the container. For some use cases (such as the
+/// [Command Pattern][command]), it is important that every value is observed.
+///
+/// This type ensures the associated code is executed for each value sent.
+/// Additionally, unlike other channel types, this code is scheduled to be
+/// executed by Cushy automatically instead of requiring additional threads or
+/// an external async runtime.
+///
+/// [command]: https://en.wikipedia.org/wiki/Command_pattern
+#[derive(Debug)]
+pub struct Channel<T> {
+    data: Arc<ChannelData<T>>,
+}
+
+impl<T> Channel<T>
+where
+    T: Send + 'static,
+{
+    /// Returns a channel that executes `on_receive` for each value sent.
+    ///
+    /// The returned channel will never be considered full and will panic if a
+    /// large enough queue cannot be allocated.
+    #[must_use]
+    pub fn unbounded<F>(mut on_receive: F) -> Self
+    where
+        F: FnMut(T) + Send + 'static,
+    {
+        Self::new(
+            None,
+            Box::new(move |value| {
+                on_receive(value);
+                Ok(())
+            }),
+        )
+    }
+
+    /// Returns a channel that executes `on_receive` for each value sent. The
+    /// channel will be disconnected if the callback returns
+    /// `Err(CallbackDisconnected)`.
+    ///
+    /// The returned channel will never be considered full and will panic if a
+    /// large enough queue cannot be allocated.
+    #[must_use]
+    pub fn unbounded_try<F>(mut on_receive: F) -> Self
+    where
+        F: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
+    {
+        Self::new(
+            None,
+            Box::new(move |value| {
+                on_receive(value).map_err(|_| ChannelCallbackError::Disconnected)
+            }),
+        )
+    }
+
+    /// Returns a channel that executes the future returned from `on_receive`
+    /// for each value sent.
+    ///
+    /// The returned channel will never be considered full and will panic if a
+    /// large enough queue cannot be allocated.
+    #[must_use]
+    pub fn unbounded_async<F, Fut>(mut on_receive: F) -> Self
+    where
+        F: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        Self::new(
+            None,
+            Box::new(move |value| {
+                let future = on_receive(value);
+                Err(ChannelCallbackError::Async(Box::new(async move {
+                    future.await;
+                    Ok(())
+                })))
+            }),
+        )
+    }
+
+    /// Returns a channel that executes the future returned from `on_receive`
+    /// for each value sent. The channel will be disconnected if the callback
+    /// returns `Err(CallbackDisconnected)`.
+    ///
+    /// The returned channel will never be considered full and will panic if a
+    /// large enough queue cannot be allocated.
+    #[must_use]
+    pub fn unbounded_async_try<F, Fut>(mut on_receive: F) -> Self
+    where
+        F: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(), CallbackDisconnected>> + Send + 'static,
+    {
+        Self::new(
+            None,
+            Box::new(move |value| Err(ChannelCallbackError::Async(Box::new(on_receive(value))))),
+        )
+    }
+
+    /// Returns a bounded channel that executes `on_receive` for each value
+    /// sent.
+    ///
+    /// The returned channel will only allow `capacity` values to be queued at
+    /// any moment in time. Each `send` function documents what happens when the
+    /// channel is full.
+    #[must_use]
+    pub fn bounded<F>(capacity: usize, mut on_receive: F) -> Self
+    where
+        F: FnMut(T) + Send + 'static,
+    {
+        Self::new(
+            Some(capacity),
+            Box::new(move |value| {
+                on_receive(value);
+                Ok(())
+            }),
+        )
+    }
+
+    /// Returns a bounded channel that executes `on_receive` for each value
+    /// sent. The channel will be disconnected if the callback returns
+    /// `Err(CallbackDisconnected)`.
+    ///
+    /// The returned channel will only allow `capacity` values to be queued at
+    /// any moment in time. Each `send` function documents what happens when the
+    /// channel is full.
+    #[must_use]
+    pub fn bounded_try<F>(capacity: usize, mut on_receive: F) -> Self
+    where
+        F: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
+    {
+        Self::new(
+            Some(capacity),
+            Box::new(move |value| {
+                on_receive(value).map_err(|_| ChannelCallbackError::Disconnected)
+            }),
+        )
+    }
+
+    /// Returns a bounded channel that executes the future returned from
+    /// `on_receive` for each value sent.
+    ///
+    /// The returned channel will only allow `capacity` values to be queued at
+    /// any moment in time. Each `send` function documents what happens when the
+    /// channel is full.
+    #[must_use]
+    pub fn bounded_async<F, Fut>(capacity: usize, mut on_receive: F) -> Self
+    where
+        F: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        Self::new(
+            Some(capacity),
+            Box::new(move |value| {
+                let future = on_receive(value);
+                Err(ChannelCallbackError::Async(Box::new(async move {
+                    future.await;
+                    Ok(())
+                })))
+            }),
+        )
+    }
+
+    /// Returns a bounded channel that executes the future returned from `on_receive`
+    /// for each value sent. The channel will be disconnected if the callback
+    /// returns `Err(CallbackDisconnected)`.
+    ///
+    /// The returned channel will only allow `capacity` values to be queued at
+    /// any moment in time. Each `send` function documents what happens when the
+    /// channel is full.
+    #[must_use]
+    pub fn bounded_async_try<F, Fut>(capacity: usize, mut on_receive: F) -> Self
+    where
+        F: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(), CallbackDisconnected>> + Send + 'static,
+    {
+        Self::new(
+            Some(capacity),
+            Box::new(move |value| Err(ChannelCallbackError::Async(Box::new(on_receive(value))))),
+        )
+    }
+
+    fn new(limit: Option<usize>, callback: Box<dyn AnyChannelCallback<T>>) -> Self {
+        let (queue, limit) = match limit {
+            Some(limit) => (VecDeque::with_capacity(limit), limit),
+            None => (VecDeque::new(), usize::MAX),
+        };
+        let this = Self {
+            data: Arc::new(ChannelData {
+                condvar: Condvar::new(),
+                synced: Mutex::new(SyncedChannelData {
+                    queue,
+                    limit,
+                    instances: 1,
+                    wakers: Vec::new(),
+                    callback: Some(callback),
+                }),
+            }),
+        };
+        enqueue_task(BackgroundTask::Channel(ChannelTask::Register {
+            id: this.id(),
+            data: this.data.clone(),
+        }));
+        this
+    }
+
+    /// Sends `value` to this channel.
+    ///
+    /// Returns `Some(value)` if the channel is disconnected.
+    ///
+    /// If the channel is full, this function will block the current thread
+    /// until space is made available. If another Channel's `on_receive` is
+    /// sending a value to a bounded channel, that `on_receive` should be async
+    /// and use [`send_async()`](Self::send_async) instead.
+    #[allow(clippy::must_use_candidate)]
+    pub fn send(&self, value: T) -> Option<T> {
+        match self.try_send_inner(value, |channel| {
+            self.data.condvar.wait(channel);
+            ControlFlow::Continue(())
+        }) {
+            Ok(()) => None,
+            Err(TrySendError::Disconnected(value) | TrySendError::Full(value)) => Some(value),
+        }
+    }
+
+    /// Sends `value` to this channel asynchronously.
+    ///
+    /// The future returns `Some(value)` if the channel is disconnected.
+    ///
+    /// If the channel is full, this future will wait until space is made
+    /// available before sending.
+    pub fn send_async(&self, value: T) -> SendAsync<'_, T> {
+        SendAsync {
+            value: Some(value),
+            channel: self,
+        }
+    }
+
+    /// Tries to send `value` to this channel. Returns an error if unable to
+    /// send.
+    ///
+    /// # Errors
+    ///
+    /// - When the channel is disconnected, [`TrySendError::Disconnected`] will
+    ///   be returned.
+    /// - When the channel is full, [`TrySendError::Full`] will
+    ///   be returned.
+    pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
+        self.try_send_inner(value, |_| ControlFlow::Break(()))
+    }
+
+    fn try_send_inner(
+        &self,
+        value: T,
+        mut when_full: impl FnMut(&mut MutexGuard<'_, SyncedChannelData<T>>) -> ControlFlow<()>,
+    ) -> Result<(), TrySendError<T>> {
+        let mut channel = self.data.synced.lock();
+        while channel.callback.is_some() {
+            if channel.queue.len() >= channel.limit {
+                match when_full(&mut channel) {
+                    ControlFlow::Continue(()) => continue,
+                    ControlFlow::Break(()) => return Err(TrySendError::Full(value)),
+                }
+            }
+            let should_notify = channel.queue.is_empty();
+            channel.queue.push_back(value);
+            drop(channel);
+
+            if should_notify {
+                enqueue_task(BackgroundTask::Channel(ChannelTask::Notify {
+                    id: self.id(),
+                }));
+            }
+
+            return Ok(());
+        }
+        Err(TrySendError::Disconnected(value))
+    }
+}
+
+impl<T> Channel<T> {
+    fn id(&self) -> usize {
+        Arc::as_ptr(&self.data) as usize
+    }
+}
+
+impl<T> Clone for Channel<T> {
+    fn clone(&self) -> Self {
+        let mut channel = self.data.synced.lock();
+        channel.instances += 1;
+        Self {
+            data: self.data.clone(),
+        }
+    }
+}
+
+impl<T> Drop for Channel<T> {
+    fn drop(&mut self) {
+        let mut channel = self.data.synced.lock();
+        channel.instances -= 1;
+
+        if channel.instances == 0 {
+            drop(channel);
+            enqueue_task(BackgroundTask::Channel(ChannelTask::Unregister(self.id())));
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ChannelData<T> {
+    condvar: Condvar,
+    synced: Mutex<SyncedChannelData<T>>,
+}
+
+struct SyncedChannelData<T> {
+    queue: VecDeque<T>,
+    limit: usize,
+    instances: usize,
+    wakers: Vec<Waker>,
+
+    callback: Option<Box<dyn AnyChannelCallback<T>>>,
+}
+
+impl<T> Debug for SyncedChannelData<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SyncedChannelData")
+            .field("queue", &self.queue)
+            .field("limit", &self.limit)
+            .field("instances", &self.instances)
+            .field("wakers", &self.wakers)
+            .field(
+                "callback",
+                &if self.callback.is_some() {
+                    "(Connected)"
+                } else {
+                    "(Disconnected)"
+                },
+            )
+            .finish()
+    }
+}
+
+trait AnyChannelCallback<T>: Send + 'static {
+    fn invoke(&mut self, value: T) -> Result<(), ChannelCallbackError>;
+}
+
+impl<F, T> AnyChannelCallback<T> for F
+where
+    F: FnMut(T) -> Result<(), ChannelCallbackError> + Send + 'static,
+{
+    fn invoke(&mut self, value: T) -> Result<(), ChannelCallbackError> {
+        self(value)
+    }
+}
+
+enum ChannelCallbackError {
+    Async(Box<dyn Future<Output = Result<(), CallbackDisconnected>>>),
+    Disconnected,
+}
+
+#[test]
+fn channel_basics() {
+    use crate::value::{Destination, Dynamic, Source};
+    let result = Dynamic::new(0);
+    let result_reader = result.create_reader();
+    let channel = Channel::<usize>::unbounded(move |value| result.set(dbg!(value)));
+    assert!(!result_reader.has_updated());
+    channel.send(1);
+    result_reader.block_until_updated();
+    assert_eq!(result_reader.get(), 1);
+}
+
+#[test]
+fn async_channels() {
+    use crate::value::{Destination, Dynamic, Source};
+
+    let result = Dynamic::new(0);
+    let result_reader = result.create_reader();
+    let channel2 = Channel::<usize>::unbounded_async(move |value| {
+        let result = result.clone();
+        async move {
+            result.set(dbg!(value));
+        }
+    });
+    let channel1 = Channel::<usize>::unbounded_async(move |value| {
+        let channel2 = channel2.clone();
+        async move {
+            channel2.send(dbg!(value));
+        }
+    });
+    assert!(!result_reader.has_updated());
+    channel1.send(1);
+    result_reader.block_until_updated();
+    assert_eq!(result_reader.get(), 1);
+    channel1.send(2);
+    result_reader.block_until_updated();
+    assert_eq!(result_reader.get(), 2);
+}

--- a/src/reactive/channel.rs
+++ b/src/reactive/channel.rs
@@ -1,55 +1,194 @@
-//! A reactive multi-sender, single-consumer (mpsc) channel for Cushy.
-
+//! Reactive channels for Cushy
+//!
+//! Channels ensure that every message sent is delivered to a receiver. Dynamics
+//! contain values and can provide reactivity, but if a dynamic is updated more
+//! quickly than the change callbacks are executed, it is possible for change
+//! callbacks to not observe every value stored in the Dynamic. Channels allow
+//! building data flows that ensure every value written is observed.
+//!
+//! Cushy supports two types of channels:
+//!
+//! - Multi-Producer, Single-Consumer (MPSC): One or more [`Sender<T>`]s send
+//!   values to either a [`Receiver<T>`] or a callback function.
+//!
+//!   Created by:
+//!
+//!   - [`unbounded()`]
+//!   - [`bounded()`]
+//!   - [`build()`]`.finish()`/`build().bound(capacity).finish()`
+//!
+//! - Broadcast: A [`Broadcaster<T>`] or a [`BroadcastChannel<T>`] sends values
+//!   to one or more callback functions. This type requires `T` to implement
+//!   `Clone` as each callback receives its own clone of the value being
+//!   broadcast.
+//!
+//!   Broadcast channels ensure every callback associated is completed for each
+//!   value received before receiving the next value.
+//!
+//!   Created by:
+//!   - [`BroadcastChannel::unbounded()`]
+//!   - [`BroadcastChannel::bounded()`]
+//!   - [`build()`]`broadcasting().finish()`/`build().bound(capacity).broadcasting().finish()`
+//!
+//! All channel types support being either unbounded or bounded. An unbounded
+//! channel dynamically allocates its queue and grows as needed. It can cause
+//! unexpected memory use or panics if the queues grow too large for the
+//! available system memory. Bounded channels allocate a buffer of a known
+//! capacity and can block on send or return errors when the queue is full.
+//!
+//! One of the features provided by Cushy's channels are the abilility to attach
+//! callbacks to be executed when values are sent. Instead of needing to
+//! manually spawn threads or async tasks, these callbacks are automatically
+//! scheduled by Cushy, making channel reactivity feel similar to
+//! [`Dynamic<T>`](crate::value::Dynamic) reactivity. However, channels
+//! guarantee that the callbacks associated with them receive *every* value
+//! written, while dynamics only guarantee that the latest written value will be
+//! observed.
+//!
+//! # Blocking callbacks
+//!
+//! When a callback might block while waiting on another thread, a network task,
+//! or some other operation that may take a long time or require synchronization
+//! that could block (e.g., mutexes), it should be considered a *blocking*
+//! callback. Each blocking callback is executed in a way that ensures it cannot
+//! block any other operation while waiting for new values to be sent.
+//!
+//! These callbacks can be configured using:
+//!
+//! - [`Receiver::on_receive`]
+//! - [`BroadcastChannel::on_receive`]
+//! - [`Builder::on_receive`]
+//!
+//! # Non-blocking callbacks
+//!
+//! When a callback will never block for a significant amount of time or in a
+//! way that depends on other threads or callbacks or external resources, a
+//! non-blocking callback can be used. These callbacks are executed in a shared
+//! execution environment that minimizes resource consumption compared to what
+//! is required to execute blocking callbacks.
+//!
+//! These callbacks can be configured using:
+//!
+//! - [`Receiver::on_receive_nonblocking`]
+//! - [`BroadcastChannel::on_receive_nonblocking`]
+//! - [`Builder::on_receive_nonblocking`]
+//!
+//! # Async callbacks
+//!
+//! If a callback needs to `await` a future, an async callback can be used.
+//! These callbacks are functions that take a value and return a future that can
+//! be awaited to process the value. The future returned is awaited to
+//! completion before the next value is received from the channel.
+//!
+//! These callbacks can be configured using:
+//!
+//! - [`Receiver::on_receive_async`]
+//! - [`BroadcastChannel::on_receive_async`]
+//! - [`Builder::on_receive_async`]
 use std::collections::VecDeque;
 use std::fmt::{self, Debug};
 use std::future::Future;
 use std::ops::ControlFlow;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, Waker};
+use std::sync::{mpsc, Arc};
+use std::task::{ready, Context, Poll, Waker};
 
+use builder::Builder;
 use parking_lot::{Condvar, Mutex, MutexGuard};
+use sealed::{AnyChannelCallback, AsyncCallbackFuture, CallbackKind, ChannelCallbackError};
 
 use crate::reactive::{enqueue_task, BackgroundTask, ChannelTask};
 use crate::value::CallbackDisconnected;
 
-/// An error occurred while trying to send a value.
+pub mod builder;
+
+/// Returns multi-producer, single-consumer channel with no limit to the number
+/// of values enqueued.
+#[must_use]
+pub fn unbounded<T>() -> (Sender<T>, Receiver<T>)
+where
+    T: Send + 'static,
+{
+    Builder::new().finish()
+}
+
+/// Returns multi-producer, single-consumer channel that limits queued values to
+/// `capacity` items.
+#[must_use]
+pub fn bounded<T>(capacity: usize) -> (Sender<T>, Receiver<T>)
+where
+    T: Send + 'static,
+{
+    Builder::new().bounded(capacity).finish()
+}
+
+/// Returns a [`Builder`] for a Cushy channel.
+pub fn build<T>() -> Builder<T> {
+    Builder::default()
+}
+
+mod sealed {
+    use std::future::Future;
+    use std::pin::Pin;
+
+    pub enum CallbackKind<T> {
+        Blocking(Box<dyn FnMut(T) -> Result<(), super::CallbackDisconnected> + Send + 'static>),
+        NonBlocking(Box<dyn AnyChannelCallback<T>>),
+    }
+
+    pub trait AnyChannelCallback<T>: Send + 'static {
+        fn invoke(&mut self, value: T) -> Result<(), ChannelCallbackError>;
+    }
+
+    pub enum ChannelCallbackError {
+        Async(AsyncCallbackFuture),
+        Disconnected,
+    }
+
+    pub type AsyncCallbackFuture =
+        Pin<Box<dyn Future<Output = Result<(), super::CallbackDisconnected>>>>;
+}
+
+/// An error occurred while trying to send a value to a channel.
 pub enum TrySendError<T> {
-    /// The recipient was full.
+    /// The channel was full.
     Full(T),
-    /// The recipient is no longer reachable.
+    /// The channel no longer has any associated behaviors or receivers.
     Disconnected(T),
 }
 
-/// A future that sends a message to a [`Channel<T>`].
+/// A future that sends a value to a [channel](self).
 #[must_use = "Futures must be awaited to be executed"]
 pub struct SendAsync<'a, T> {
     value: Option<T>,
-    channel: &'a Channel<T>,
+    channel: &'a Sender<T>,
 }
 
 impl<T> Future for SendAsync<'_, T>
 where
-    T: Unpin + Clone + Send + 'static,
+    T: Unpin + Send + 'static,
 {
-    type Output = Option<T>;
+    type Output = Result<(), T>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let Some(value) = self.value.take() else {
-            return Poll::Ready(None);
+            return Poll::Ready(Ok(()));
         };
-        match self.channel.try_send_inner(value, |channel| {
-            let will_wake = channel
-                .wakers
-                .iter()
-                .any(|waker| waker.will_wake(cx.waker()));
-            if !will_wake {
-                channel.wakers.push(cx.waker().clone());
-            }
-            ControlFlow::Break(())
-        }) {
-            Ok(()) => Poll::Ready(None),
-            Err(TrySendError::Disconnected(value)) => Poll::Ready(Some(value)),
+        match self
+            .channel
+            .data
+            .try_send_inner(value, channel_id(&self.channel.data), |channel| {
+                let will_wake = channel
+                    .wakers
+                    .iter()
+                    .any(|waker| waker.will_wake(cx.waker()));
+                if !will_wake {
+                    channel.wakers.push(cx.waker().clone());
+                }
+                ControlFlow::Break(())
+            }) {
+            Ok(()) => Poll::Ready(Ok(())),
+            Err(TrySendError::Disconnected(value)) => Poll::Ready(Err(value)),
             Err(TrySendError::Full(value)) => {
                 self.value = Some(value);
                 Poll::Pending
@@ -61,23 +200,24 @@ where
 pub(super) trait AnyChannel: Send + Sync + 'static {
     fn should_poll(&self) -> bool;
     fn poll(&self, futures: &mut Vec<ChannelCallbackFuture>) -> bool;
-    fn disconnect_callback(&self);
+    fn disconnect(&self);
 }
 
-impl<T> AnyChannel for ChannelData<T>
+impl<T, Behavior> AnyChannel for Arc<ChannelData<T, Behavior>>
 where
     T: Send + 'static,
+    Behavior: CallbackBehavior<T>,
 {
     fn should_poll(&self) -> bool {
         let channel = self.synced.lock();
-        !channel.queue.is_empty() && channel.callback.is_some()
+        !channel.queue.is_empty() && channel.behavior.connected()
     }
 
     fn poll(&self, futures: &mut Vec<ChannelCallbackFuture>) -> bool {
         let mut channel = self.synced.lock();
 
         let Some(value) = channel.queue.pop_front() else {
-            return channel.instances > 0 && channel.callback.is_some();
+            return channel.senders > 0 && channel.behavior.connected();
         };
 
         self.condvar.notify_all();
@@ -85,26 +225,27 @@ where
             waker.wake();
         }
 
-        if let Some(callback) = &mut channel.callback {
-            match callback.invoke(value) {
-                Ok(()) => {}
-                Err(ChannelCallbackError::Async(future)) => {
-                    futures.push(ChannelCallbackFuture {
-                        future: Pin::from(future),
-                    });
-                }
-                Err(ChannelCallbackError::Disconnected) => {
-                    channel.callback = None;
-                    return false;
-                }
+        match channel.behavior.invoke(value, self) {
+            Ok(()) => {}
+            Err(ChannelCallbackError::Async(future)) => {
+                futures.push(ChannelCallbackFuture { future });
+            }
+            Err(ChannelCallbackError::Disconnected) => {
+                return false;
             }
         }
 
         true
     }
 
-    fn disconnect_callback(&self) {
-        self.synced.lock().callback = None;
+    fn disconnect(&self) {
+        let mut data = self.synced.lock();
+        data.behavior.disconnect();
+        for waker in data.wakers.drain(..) {
+            waker.wake();
+        }
+        drop(data);
+        self.condvar.notify_all();
     }
 }
 
@@ -112,239 +253,47 @@ pub(super) struct ChannelCallbackFuture {
     pub(super) future: Pin<Box<dyn Future<Output = Result<(), CallbackDisconnected>>>>,
 }
 
-/// A reactive multi-sender, single-consumer (mpsc) channel that executes code
-/// in the background when values are received.
-///
-/// A [`Dynamic<T>`](crate::value::Dynamic) is a container for a `T` that can be
-/// reacted against. Due to this design, it is possible to not observe *every*
-/// value that passes through the container. For some use cases (such as the
-/// [Command Pattern][command]), it is important that every value is observed.
-///
-/// This type ensures the associated code is executed for each value sent.
-/// Additionally, unlike other channel types, this code is scheduled to be
-/// executed by Cushy automatically instead of requiring additional threads or
-/// an external async runtime.
-///
-/// [command]: https://en.wikipedia.org/wiki/Command_pattern
+/// A sender of values to a [channel](self).
 #[derive(Debug)]
-pub struct Channel<T> {
-    data: Arc<ChannelData<T>>,
+pub struct Sender<T> {
+    data: Arc<ChannelData<T, SingleCallback<T>>>,
 }
 
-impl<T> Channel<T>
+impl<T> Sender<T>
 where
     T: Send + 'static,
 {
-    /// Returns a channel that executes `on_receive` for each value sent.
-    ///
-    /// The returned channel will never be considered full and will panic if a
-    /// large enough queue cannot be allocated.
-    #[must_use]
-    pub fn unbounded<F>(mut on_receive: F) -> Self
-    where
-        F: FnMut(T) + Send + 'static,
-    {
-        Self::new(
-            None,
-            Box::new(move |value| {
-                on_receive(value);
-                Ok(())
-            }),
-        )
-    }
-
-    /// Returns a channel that executes `on_receive` for each value sent. The
-    /// channel will be disconnected if the callback returns
-    /// `Err(CallbackDisconnected)`.
-    ///
-    /// The returned channel will never be considered full and will panic if a
-    /// large enough queue cannot be allocated.
-    #[must_use]
-    pub fn unbounded_try<F>(mut on_receive: F) -> Self
-    where
-        F: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
-    {
-        Self::new(
-            None,
-            Box::new(move |value| {
-                on_receive(value).map_err(|_| ChannelCallbackError::Disconnected)
-            }),
-        )
-    }
-
-    /// Returns a channel that executes the future returned from `on_receive`
-    /// for each value sent.
-    ///
-    /// The returned channel will never be considered full and will panic if a
-    /// large enough queue cannot be allocated.
-    #[must_use]
-    pub fn unbounded_async<F, Fut>(mut on_receive: F) -> Self
-    where
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: Future<Output = ()> + Send + 'static,
-    {
-        Self::new(
-            None,
-            Box::new(move |value| {
-                let future = on_receive(value);
-                Err(ChannelCallbackError::Async(Box::new(async move {
-                    future.await;
-                    Ok(())
-                })))
-            }),
-        )
-    }
-
-    /// Returns a channel that executes the future returned from `on_receive`
-    /// for each value sent. The channel will be disconnected if the callback
-    /// returns `Err(CallbackDisconnected)`.
-    ///
-    /// The returned channel will never be considered full and will panic if a
-    /// large enough queue cannot be allocated.
-    #[must_use]
-    pub fn unbounded_async_try<F, Fut>(mut on_receive: F) -> Self
-    where
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<(), CallbackDisconnected>> + Send + 'static,
-    {
-        Self::new(
-            None,
-            Box::new(move |value| Err(ChannelCallbackError::Async(Box::new(on_receive(value))))),
-        )
-    }
-
-    /// Returns a bounded channel that executes `on_receive` for each value
-    /// sent.
-    ///
-    /// The returned channel will only allow `capacity` values to be queued at
-    /// any moment in time. Each `send` function documents what happens when the
-    /// channel is full.
-    #[must_use]
-    pub fn bounded<F>(capacity: usize, mut on_receive: F) -> Self
-    where
-        F: FnMut(T) + Send + 'static,
-    {
-        Self::new(
-            Some(capacity),
-            Box::new(move |value| {
-                on_receive(value);
-                Ok(())
-            }),
-        )
-    }
-
-    /// Returns a bounded channel that executes `on_receive` for each value
-    /// sent. The channel will be disconnected if the callback returns
-    /// `Err(CallbackDisconnected)`.
-    ///
-    /// The returned channel will only allow `capacity` values to be queued at
-    /// any moment in time. Each `send` function documents what happens when the
-    /// channel is full.
-    #[must_use]
-    pub fn bounded_try<F>(capacity: usize, mut on_receive: F) -> Self
-    where
-        F: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
-    {
-        Self::new(
-            Some(capacity),
-            Box::new(move |value| {
-                on_receive(value).map_err(|_| ChannelCallbackError::Disconnected)
-            }),
-        )
-    }
-
-    /// Returns a bounded channel that executes the future returned from
-    /// `on_receive` for each value sent.
-    ///
-    /// The returned channel will only allow `capacity` values to be queued at
-    /// any moment in time. Each `send` function documents what happens when the
-    /// channel is full.
-    #[must_use]
-    pub fn bounded_async<F, Fut>(capacity: usize, mut on_receive: F) -> Self
-    where
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: Future<Output = ()> + Send + 'static,
-    {
-        Self::new(
-            Some(capacity),
-            Box::new(move |value| {
-                let future = on_receive(value);
-                Err(ChannelCallbackError::Async(Box::new(async move {
-                    future.await;
-                    Ok(())
-                })))
-            }),
-        )
-    }
-
-    /// Returns a bounded channel that executes the future returned from `on_receive`
-    /// for each value sent. The channel will be disconnected if the callback
-    /// returns `Err(CallbackDisconnected)`.
-    ///
-    /// The returned channel will only allow `capacity` values to be queued at
-    /// any moment in time. Each `send` function documents what happens when the
-    /// channel is full.
-    #[must_use]
-    pub fn bounded_async_try<F, Fut>(capacity: usize, mut on_receive: F) -> Self
-    where
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<(), CallbackDisconnected>> + Send + 'static,
-    {
-        Self::new(
-            Some(capacity),
-            Box::new(move |value| Err(ChannelCallbackError::Async(Box::new(on_receive(value))))),
-        )
-    }
-
-    fn new(limit: Option<usize>, callback: Box<dyn AnyChannelCallback<T>>) -> Self {
-        let (queue, limit) = match limit {
-            Some(limit) => (VecDeque::with_capacity(limit), limit),
-            None => (VecDeque::new(), usize::MAX),
-        };
-        let this = Self {
-            data: Arc::new(ChannelData {
-                condvar: Condvar::new(),
-                synced: Mutex::new(SyncedChannelData {
-                    queue,
-                    limit,
-                    instances: 1,
-                    wakers: Vec::new(),
-                    callback: Some(callback),
-                }),
-            }),
-        };
-        enqueue_task(BackgroundTask::Channel(ChannelTask::Register {
-            id: this.id(),
-            data: this.data.clone(),
-        }));
-        this
-    }
-
     /// Sends `value` to this channel.
     ///
-    /// Returns `Some(value)` if the channel is disconnected.
-    ///
     /// If the channel is full, this function will block the current thread
-    /// until space is made available. If another Channel's `on_receive` is
-    /// sending a value to a bounded channel, that `on_receive` should be async
-    /// and use [`send_async()`](Self::send_async) instead.
-    #[allow(clippy::must_use_candidate)]
-    pub fn send(&self, value: T) -> Option<T> {
-        match self.try_send_inner(value, |channel| {
-            self.data.condvar.wait(channel);
-            ControlFlow::Continue(())
-        }) {
-            Ok(()) => None,
-            Err(TrySendError::Disconnected(value) | TrySendError::Full(value)) => Some(value),
+    /// until space is made available. If one channel's `on_receive` is sending
+    /// a value to a bounded channel, that `on_receive` should be
+    /// `on_receive_async` instead and use [`send_async()`](Self::send_async).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(value)` if the channel is disconnected.
+    pub fn send(&self, value: T) -> Result<(), T> {
+        match self
+            .data
+            .try_send_inner(value, channel_id(&self.data), |channel| {
+                self.data.condvar.wait(channel);
+                ControlFlow::Continue(())
+            }) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Disconnected(value) | TrySendError::Full(value)) => Err(value),
         }
     }
 
     /// Sends `value` to this channel asynchronously.
     ///
-    /// The future returns `Some(value)` if the channel is disconnected.
-    ///
     /// If the channel is full, this future will wait until space is made
     /// available before sending.
+    ///
+    /// # Errors
+    ///
+    /// The returned future will return `Err(value)` if the channel is
+    /// disconnected.
     pub fn send_async(&self, value: T) -> SendAsync<'_, T> {
         SendAsync {
             value: Some(value),
@@ -362,30 +311,427 @@ where
     /// - When the channel is full, [`TrySendError::Full`] will
     ///   be returned.
     pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
-        self.try_send_inner(value, |_| ControlFlow::Break(()))
+        self.data
+            .try_send_inner(value, channel_id(&self.data), |_| ControlFlow::Break(()))
+    }
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        let mut channel = self.data.synced.lock();
+        channel.senders += 1;
+        Self {
+            data: self.data.clone(),
+        }
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        let mut channel = self.data.synced.lock();
+        channel.senders -= 1;
+
+        if channel.senders == 0 {
+            match &channel.behavior {
+                SingleCallback::Receiver => {
+                    drop(channel);
+                    self.data.condvar.notify_all();
+                }
+                SingleCallback::Callback(_) => {
+                    drop(channel);
+                    enqueue_task(BackgroundTask::Channel(ChannelTask::Unregister(
+                        channel_id(&self.data),
+                    )));
+                }
+                SingleCallback::Disconnected => {}
+            }
+        }
+    }
+}
+
+enum SingleCallback<T> {
+    Receiver,
+    Callback(Box<dyn AnyChannelCallback<T>>),
+    Disconnected,
+}
+
+impl<T> CallbackBehavior<T> for SingleCallback<T>
+where
+    T: Send + 'static,
+{
+    fn connected(&self) -> bool {
+        !matches!(self, Self::Disconnected)
+    }
+
+    fn disconnect(&mut self) {
+        *self = Self::Disconnected;
+    }
+
+    fn invoke(
+        &mut self,
+        value: T,
+        _channel: &Arc<ChannelData<T, Self>>,
+    ) -> Result<(), ChannelCallbackError> {
+        let cb = match self {
+            SingleCallback::Receiver => unreachable!("callback installed without callback"),
+            SingleCallback::Callback(cb) => cb,
+            SingleCallback::Disconnected => return Err(ChannelCallbackError::Disconnected),
+        };
+
+        match cb.invoke(value) {
+            Err(ChannelCallbackError::Disconnected) => {
+                *self = Self::Disconnected;
+                Err(ChannelCallbackError::Disconnected)
+            }
+            other => other,
+        }
+    }
+}
+
+impl<T> Debug for SingleCallback<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SingleCallback::Receiver => f.write_str("0 callbacks"),
+            SingleCallback::Callback(_) => f.write_str("1 callback"),
+            SingleCallback::Disconnected => f.write_str("disconnected"),
+        }
+    }
+}
+
+enum BroadcastCallback<T> {
+    Blocking {
+        sender: mpsc::SyncSender<(T, Waker)>,
+        result: mpsc::Receiver<()>,
+    },
+    NonBlocking(Box<dyn AnyChannelCallback<T>>),
+}
+
+impl<T> BroadcastCallback<T> {
+    fn spawn_blocking(
+        mut cb: Box<dyn FnMut(T) -> Result<(), super::CallbackDisconnected> + Send + 'static>,
+    ) -> Self
+    where
+        T: Send + 'static,
+    {
+        let (value_sender, value_receiver) = mpsc::sync_channel::<(T, Waker)>(1);
+        let (result_sender, result_receiver) = mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            while let Ok((value, waker)) = value_receiver.recv() {
+                if let Ok(()) = cb(value) {
+                    if result_sender.send(()).is_err() {
+                        return;
+                    }
+                    waker.wake();
+                } else {
+                    drop(result_sender);
+                    waker.wake();
+                    return;
+                }
+            }
+        });
+        Self::Blocking {
+            sender: value_sender,
+            result: result_receiver,
+        }
+    }
+}
+
+struct MultipleCallbacks<T>(Vec<BroadcastCallback<T>>);
+
+impl<T> CallbackBehavior<T> for MultipleCallbacks<T>
+where
+    T: Unpin + Clone + Send + 'static,
+{
+    fn connected(&self) -> bool {
+        !self.0.is_empty()
+    }
+
+    fn disconnect(&mut self) {
+        self.0.clear();
+    }
+
+    fn invoke(
+        &mut self,
+        value: T,
+        channel: &Arc<ChannelData<T, Self>>,
+    ) -> Result<(), ChannelCallbackError> {
+        let mut sent_one = false;
+
+        let mut i = 0;
+        let mut value = TakeN::new(value, self.0.len());
+        while i < self.0.len() {
+            match &mut self.0[i] {
+                BroadcastCallback::Blocking { .. } => {
+                    return Err(ChannelCallbackError::Async(Box::pin(BroadcastSend {
+                        value,
+                        sent_one,
+                        data: channel.clone(),
+                        current_recipient_future: None,
+                        current_is_blocking: false,
+                        next_recipient: i,
+                    })))
+                }
+                BroadcastCallback::NonBlocking(cb) => {
+                    match cb.invoke(value.next().expect("enough value clones")) {
+                        Ok(()) => {
+                            sent_one = true;
+                        }
+                        Err(ChannelCallbackError::Disconnected) => {
+                            self.0.remove(i);
+                            continue;
+                        }
+                        Err(ChannelCallbackError::Async(future)) => {
+                            return Err(ChannelCallbackError::Async(Box::pin(BroadcastSend {
+                                value,
+                                sent_one,
+                                data: channel.clone(),
+                                current_recipient_future: Some(future),
+                                current_is_blocking: false,
+                                next_recipient: i + 1,
+                            })))
+                        }
+                    }
+                }
+            }
+
+            i += 1;
+        }
+
+        if sent_one {
+            Ok(())
+        } else {
+            Err(ChannelCallbackError::Disconnected)
+        }
+    }
+}
+
+impl<T> Debug for MultipleCallbacks<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0.len() == 1 {
+            f.write_str("1 callback")
+        } else {
+            write!(f, "{} callbacks", self.0.len())
+        }
+    }
+}
+
+struct TakeN<T> {
+    value: Option<T>,
+    remaining: usize,
+}
+
+impl<T> TakeN<T> {
+    fn new(value: T, count: usize) -> Self {
+        Self {
+            value: Some(value),
+            remaining: count,
+        }
+    }
+}
+
+impl<T> Iterator for TakeN<T>
+where
+    T: Clone,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.remaining = self.remaining.saturating_sub(1);
+        if self.remaining > 0 {
+            self.value.clone()
+        } else {
+            self.value.take()
+        }
+    }
+}
+
+struct BroadcastSend<T> {
+    sent_one: bool,
+    value: TakeN<T>,
+    next_recipient: usize,
+    data: Arc<ChannelData<T, MultipleCallbacks<T>>>,
+    current_recipient_future: Option<AsyncCallbackFuture>,
+    current_is_blocking: bool,
+}
+
+impl<T> BroadcastSend<T>
+where
+    T: Unpin + Clone + Send + 'static,
+{
+    fn poll_tasks(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        if let Some(future) = &mut self.current_recipient_future {
+            match ready!(future.as_mut().poll(cx)) {
+                Ok(()) => {
+                    self.current_recipient_future = None;
+                    self.sent_one = true;
+                }
+                Err(CallbackDisconnected) => {
+                    self.current_recipient_future = None;
+                }
+            }
+        } else if self.current_is_blocking {
+            let mut data = self.data.synced.lock();
+            let BroadcastCallback::Blocking { result, .. } = &data.behavior.0[self.next_recipient]
+            else {
+                unreachable!("valid state");
+            };
+            match result.try_recv() {
+                Ok(()) => {
+                    self.next_recipient += 1;
+                }
+                Err(mpsc::TryRecvError::Empty) => return Poll::Pending,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    data.behavior.0.remove(self.next_recipient);
+                }
+            }
+            self.current_is_blocking = false;
+        }
+        Poll::Ready(())
+    }
+}
+
+impl<T> Future for BroadcastSend<T>
+where
+    T: Unpin + Clone + Send + 'static,
+{
+    type Output = Result<(), CallbackDisconnected>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+        ready!(this.poll_tasks(cx));
+
+        let mut data_mutex = this.data.synced.lock();
+        loop {
+            let data = &mut *data_mutex;
+            if let Some(cb) = data.behavior.0.get_mut(this.next_recipient) {
+                match cb {
+                    BroadcastCallback::Blocking { sender, .. } => {
+                        if let Ok(()) = sender.send((
+                            this.value.next().expect("enough value clones"),
+                            cx.waker().clone(),
+                        )) {
+                            this.current_is_blocking = true;
+                            drop(data_mutex);
+
+                            ready!(this.poll_tasks(cx));
+
+                            data_mutex = this.data.synced.lock();
+                            continue;
+                        }
+
+                        data.behavior.0.remove(this.next_recipient);
+                        continue;
+                    }
+                    BroadcastCallback::NonBlocking(cb) => {
+                        match cb.invoke(this.value.next().expect("enough value clones")) {
+                            Ok(()) => {
+                                this.sent_one = true;
+                            }
+                            Err(ChannelCallbackError::Disconnected) => {
+                                data.behavior.0.remove(this.next_recipient);
+                                continue;
+                            }
+                            Err(ChannelCallbackError::Async(future)) => {
+                                this.current_recipient_future = Some(future);
+                                drop(data_mutex);
+
+                                ready!(this.poll_tasks(cx));
+
+                                data_mutex = this.data.synced.lock();
+                            }
+                        }
+                    }
+                }
+
+                this.next_recipient += 1;
+            } else if this.sent_one {
+                return Poll::Ready(Ok(()));
+            } else {
+                for waker in data.wakers.drain(..) {
+                    waker.wake();
+                }
+                drop(data_mutex);
+                this.data.condvar.notify_all();
+                return Poll::Ready(Err(CallbackDisconnected));
+            }
+        }
+    }
+}
+
+trait CallbackBehavior<T>: Sized + Send + 'static {
+    fn connected(&self) -> bool;
+    fn disconnect(&mut self);
+    fn invoke(
+        &mut self,
+        value: T,
+        channel: &Arc<ChannelData<T, Self>>,
+    ) -> Result<(), ChannelCallbackError>;
+}
+
+#[derive(Debug)]
+struct ChannelData<T, Callbacks> {
+    condvar: Condvar,
+    synced: Mutex<SyncedChannelData<T, Callbacks>>,
+}
+
+impl<T, Behavior> ChannelData<T, Behavior>
+where
+    T: Send + 'static,
+    Behavior: CallbackBehavior<T>,
+{
+    fn new(
+        limit: Option<usize>,
+        behavior: Behavior,
+        senders: usize,
+        receivers: usize,
+    ) -> Arc<ChannelData<T, Behavior>> {
+        let (queue, limit) = match limit {
+            Some(limit) => (VecDeque::with_capacity(limit), limit),
+            None => (VecDeque::new(), usize::MAX),
+        };
+        let this = Arc::new(ChannelData {
+            condvar: Condvar::new(),
+            synced: Mutex::new(SyncedChannelData {
+                queue,
+                limit,
+                senders,
+                receivers,
+                wakers: Vec::new(),
+                behavior,
+            }),
+        });
+        enqueue_task(BackgroundTask::Channel(ChannelTask::Register {
+            id: channel_id(&this),
+            data: Arc::new(this.clone()),
+        }));
+        this
     }
 
     fn try_send_inner(
         &self,
         value: T,
-        mut when_full: impl FnMut(&mut MutexGuard<'_, SyncedChannelData<T>>) -> ControlFlow<()>,
+        id: usize,
+        mut when_full: impl FnMut(
+            &mut MutexGuard<'_, SyncedChannelData<T, Behavior>>,
+        ) -> ControlFlow<()>,
     ) -> Result<(), TrySendError<T>> {
-        let mut channel = self.data.synced.lock();
-        while channel.callback.is_some() {
+        let mut channel = self.synced.lock();
+        while channel.receivers > 0 || channel.behavior.connected() {
             if channel.queue.len() >= channel.limit {
                 match when_full(&mut channel) {
                     ControlFlow::Continue(()) => continue,
                     ControlFlow::Break(()) => return Err(TrySendError::Full(value)),
                 }
             }
-            let should_notify = channel.queue.is_empty();
+            let has_receiver = channel.receivers > 0;
+            let should_notify = !has_receiver && channel.queue.is_empty();
             channel.queue.push_back(value);
             drop(channel);
 
             if should_notify {
-                enqueue_task(BackgroundTask::Channel(ChannelTask::Notify {
-                    id: self.id(),
-                }));
+                enqueue_task(BackgroundTask::Channel(ChannelTask::Notify { id }));
+            } else if has_receiver {
+                self.condvar.notify_all();
             }
 
             return Ok(());
@@ -394,73 +740,427 @@ where
     }
 }
 
-impl<T> Channel<T> {
-    fn id(&self) -> usize {
-        Arc::as_ptr(&self.data) as usize
+struct SyncedChannelData<T, Behavior> {
+    queue: VecDeque<T>,
+    limit: usize,
+    senders: usize,
+    receivers: usize,
+    wakers: Vec<Waker>,
+
+    behavior: Behavior,
+}
+
+impl<T, Behavior> Debug for SyncedChannelData<T, Behavior>
+where
+    T: Debug,
+    Behavior: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SyncedChannelData")
+            .field("queue", &self.queue)
+            .field("limit", &self.limit)
+            .field("senders", &self.senders)
+            .field("receiers", &self.receivers)
+            .field("wakers", &self.wakers)
+            .field("behavior", &self.behavior)
+            .finish()
     }
 }
 
-impl<T> Clone for Channel<T> {
+/// A channel that broadcasts values received to one or more callbacks.
+///
+/// This type represents both a sender and a receiver in terms of determining
+/// whether a channel is "connected". This is because at any time additional
+/// callbacks can be associated through this type while also allowing values to
+/// be sent to already-installed callbacks.
+///
+/// Because of this ability to attach future callbacks, a broadcast channel can
+/// be created with no associated callbacks. When a value is sent to a channel
+/// that has a [`BroadcastChannel`] connected to it, the value will be queued
+/// even if no callbacks are currently associated. To prevent this, use
+/// [`create_broadcaster()`](Self::create_broadcaster)/[`into_broadcaster()`](Self::into_broadcaster)
+/// to create a [`Broadcaster`] for this channel and drop all
+/// [`BroadcastChannel`] instances after callbacks have been associated.
+pub struct BroadcastChannel<T> {
+    data: Arc<ChannelData<T, MultipleCallbacks<T>>>,
+}
+
+impl<T> BroadcastChannel<T>
+where
+    T: Unpin + Clone + Send + 'static,
+{
+    /// Returns broadcast channel with no limit to the number of values
+    /// enqueued.
+    #[must_use]
+    pub fn unbounded() -> Self {
+        Builder::new().broadcasting().finish()
+    }
+
+    /// Returns broadcast channel that limits queued values to `capacity` items.
+    #[must_use]
+    pub fn bounded(capacity: usize) -> Self {
+        Builder::new().broadcasting().bounded(capacity).finish()
+    }
+
+    /// Returns a builder for a broadcast channel.
+    pub fn build() -> Builder<T, builder::Broadcast<T>> {
+        Builder::new().broadcasting()
+    }
+
+    /// Sends `value` to this channel.
+    ///
+    /// If the channel is full, this function will block the current thread
+    /// until space is made available. If one channel's `on_receive` is sending
+    /// a value to a bounded channel, that `on_receive` should be
+    /// `on_receive_async` instead and use [`send_async()`](Self::send_async).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(value)` if the channel is disconnected.
+    pub fn send(&self, value: T) -> Result<(), T> {
+        match self
+            .data
+            .try_send_inner(value, channel_id(&self.data), |channel| {
+                self.data.condvar.wait(channel);
+                ControlFlow::Continue(())
+            }) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Disconnected(value) | TrySendError::Full(value)) => Err(value),
+        }
+    }
+
+    /// Sends `value` to this channel asynchronously.
+    ///
+    /// If the channel is full, this future will wait until space is made
+    /// available before sending.
+    ///
+    /// # Errors
+    ///
+    /// The returned future will return `Err(value)` if the channel is
+    /// disconnected.
+    pub fn send_async(&self, value: T) -> BroadcastAsync<'_, T> {
+        BroadcastAsync {
+            value: Some(value),
+            channel: &self.data,
+        }
+    }
+
+    /// Tries to send `value` to this channel. Returns an error if unable to
+    /// send.
+    ///
+    /// # Errors
+    ///
+    /// - When the channel is disconnected, [`TrySendError::Disconnected`] will
+    ///   be returned.
+    /// - When the channel is full, [`TrySendError::Full`] will
+    ///   be returned.
+    pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
+        self.data
+            .try_send_inner(value, channel_id(&self.data), |_| ControlFlow::Break(()))
+    }
+
+    /// Returns a [`Broadcaster`] that sends to this channel.
+    #[must_use]
+    pub fn create_broadcaster(&self) -> Broadcaster<T> {
+        let mut data = self.data.synced.lock();
+        data.senders += 1;
+        Broadcaster {
+            data: self.data.clone(),
+        }
+    }
+
+    /// Returns this instance as a [`Broadcaster`] that sends to this channel.
+    #[must_use]
+    pub fn into_broadcaster(self) -> Broadcaster<T> {
+        self.create_broadcaster()
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel.
+    ///
+    /// This function assumes `on_receive` may block while waiting on another
+    /// thread, another process, another callback, a network request, a locking
+    /// primitive, or any other number of ways that could impact other callbacks
+    /// from executing.
+    pub fn on_receive<Map>(&self, mut on_receive: Map)
+    where
+        Map: FnMut(T) + Send + 'static,
+    {
+        self.on_receive_try(move |value| {
+            on_receive(value);
+            Ok(())
+        });
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel. Once an
+    /// error is returned, this callback will be removed from the channel.
+    ///
+    /// This function assumes `on_receive` may block while waiting on another
+    /// thread, another process, another callback, a network request, a locking
+    /// primitive, or any other number of ways that could impact other callbacks
+    /// from executing.
+    ///
+    /// Once the last callback associated with a channel is removed, [`Sender`]s
+    /// will begin returning disconnected errors.
+    pub fn on_receive_try<Map>(&self, on_receive: Map)
+    where
+        Map: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
+    {
+        self.on_receive_inner(CallbackKind::Blocking(Box::new(on_receive)));
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel.
+    ///
+    /// This function assumes `on_receive` will not block while waiting on
+    /// another thread, another process, another callback, a network request, a
+    /// locking primitive, or any other number of ways that could impact other
+    /// callbacks from executing in a shared environment.
+    pub fn on_receive_nonblocking<Map>(&self, mut on_receive: Map)
+    where
+        Map: FnMut(T) + Send + 'static,
+    {
+        self.on_receive_nonblocking_try(move |value| {
+            on_receive(value);
+            Ok(())
+        });
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel. Once an
+    /// error is returned, this callback will be removed from the channel.
+    ///
+    /// This function assumes `on_receive` will not block while waiting on
+    /// another thread, another process, another callback, a network request, a
+    /// locking primitive, or any other number of ways that could impact other
+    /// callbacks from executing in a shared environment.
+    ///
+    /// Once the last callback associated with a channel is removed, [`Sender`]s
+    /// will begin returning disconnected errors.
+    pub fn on_receive_nonblocking_try<Map>(&self, mut on_receive: Map)
+    where
+        Map: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
+    {
+        self.on_receive_inner(CallbackKind::NonBlocking(Box::new(move |value| {
+            on_receive(value).map_err(|CallbackDisconnected| ChannelCallbackError::Disconnected)
+        })));
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel.
+    pub fn on_receive_async<Map, Fut>(&self, mut on_receive: Map)
+    where
+        Map: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_receive_async_try(move |value| {
+            let future = on_receive(value);
+            async move {
+                future.await;
+                Ok(())
+            }
+        });
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel. The
+    /// returned future will then be awaited. Once an error is returned, this
+    /// callback will be removed from the channel.
+    ///
+    /// Once the last callback associated with a channel is removed, [`Sender`]s
+    /// will begin returning disconnected errors.
+    pub fn on_receive_async_try<Map, Fut>(&self, mut on_receive: Map)
+    where
+        Map: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(), CallbackDisconnected>> + Send + 'static,
+    {
+        self.on_receive_inner(CallbackKind::NonBlocking(Box::new(move |value| {
+            let future = on_receive(value);
+            Err(ChannelCallbackError::Async(Box::pin(future)))
+        })));
+    }
+
+    fn on_receive_inner(&self, cb: CallbackKind<T>) {
+        let mut data = self.data.synced.lock();
+        let should_register = data.behavior.0.is_empty();
+        match cb {
+            CallbackKind::Blocking(cb) => {
+                data.behavior.0.push(BroadcastCallback::spawn_blocking(cb));
+            }
+            CallbackKind::NonBlocking(cb) => {
+                data.behavior.0.push(BroadcastCallback::NonBlocking(cb));
+            }
+        }
+        if should_register {
+            drop(data);
+            enqueue_task(BackgroundTask::Channel(ChannelTask::Register {
+                id: channel_id(&self.data),
+                data: Arc::new(self.data.clone()),
+            }));
+        }
+    }
+}
+
+impl<T> Clone for BroadcastChannel<T> {
     fn clone(&self) -> Self {
-        let mut channel = self.data.synced.lock();
-        channel.instances += 1;
+        let mut data = self.data.synced.lock();
+        data.senders += 1;
+        data.receivers += 1;
+        drop(data);
         Self {
             data: self.data.clone(),
         }
     }
 }
 
-impl<T> Drop for Channel<T> {
+impl<T> Drop for BroadcastChannel<T> {
     fn drop(&mut self) {
-        let mut channel = self.data.synced.lock();
-        channel.instances -= 1;
+        let mut data = self.data.synced.lock();
+        data.senders -= 1;
+        data.receivers -= 1;
 
-        if channel.instances == 0 {
-            drop(channel);
-            enqueue_task(BackgroundTask::Channel(ChannelTask::Unregister(self.id())));
+        let notify_disconnected = data.senders == 0 || data.behavior.0.is_empty();
+        if notify_disconnected {
+            for waker in data.wakers.drain(..) {
+                waker.wake();
+            }
+        }
+        drop(data);
+        if notify_disconnected {
+            self.data.condvar.notify_all();
+            enqueue_task(BackgroundTask::Channel(ChannelTask::Unregister(
+                channel_id(&self.data),
+            )));
         }
     }
 }
 
-#[derive(Debug)]
-struct ChannelData<T> {
-    condvar: Condvar,
-    synced: Mutex<SyncedChannelData<T>>,
+/// Sends values to a [`BroadcastChannel`].
+pub struct Broadcaster<T> {
+    data: Arc<ChannelData<T, MultipleCallbacks<T>>>,
 }
 
-struct SyncedChannelData<T> {
-    queue: VecDeque<T>,
-    limit: usize,
-    instances: usize,
-    wakers: Vec<Waker>,
-
-    callback: Option<Box<dyn AnyChannelCallback<T>>>,
-}
-
-impl<T> Debug for SyncedChannelData<T>
+impl<T> Broadcaster<T>
 where
-    T: Debug,
+    T: Unpin + Clone + Send + 'static,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SyncedChannelData")
-            .field("queue", &self.queue)
-            .field("limit", &self.limit)
-            .field("instances", &self.instances)
-            .field("wakers", &self.wakers)
-            .field(
-                "callback",
-                &if self.callback.is_some() {
-                    "(Connected)"
-                } else {
-                    "(Disconnected)"
-                },
-            )
-            .finish()
+    /// Sends `value` to this channel.
+    ///
+    /// If the channel is full, this function will block the current thread
+    /// until space is made available. If one channel's `on_receive` is sending
+    /// a value to a bounded channel, that `on_receive` should be
+    /// `on_receive_async` instead and use [`send_async()`](Self::send_async).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(value)` if the channel is disconnected.
+    pub fn send(&self, value: T) -> Result<(), T> {
+        match self
+            .data
+            .try_send_inner(value, channel_id(&self.data), |channel| {
+                self.data.condvar.wait(channel);
+                ControlFlow::Continue(())
+            }) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Disconnected(value) | TrySendError::Full(value)) => Err(value),
+        }
+    }
+
+    /// Sends `value` to this channel asynchronously.
+    ///
+    /// If the channel is full, this future will wait until space is made
+    /// available before sending.
+    ///
+    /// # Errors
+    ///
+    /// The returned future will return `Err(value)` if the channel is
+    /// disconnected.
+    pub fn send_async(&self, value: T) -> BroadcastAsync<'_, T> {
+        BroadcastAsync {
+            value: Some(value),
+            channel: &self.data,
+        }
+    }
+
+    /// Tries to send `value` to this channel. Returns an error if unable to
+    /// send.
+    ///
+    /// # Errors
+    ///
+    /// - When the channel is disconnected, [`TrySendError::Disconnected`] will
+    ///   be returned.
+    /// - When the channel is full, [`TrySendError::Full`] will
+    ///   be returned.
+    pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
+        self.data
+            .try_send_inner(value, channel_id(&self.data), |_| ControlFlow::Break(()))
     }
 }
 
-trait AnyChannelCallback<T>: Send + 'static {
-    fn invoke(&mut self, value: T) -> Result<(), ChannelCallbackError>;
+impl<T> Clone for Broadcaster<T> {
+    fn clone(&self) -> Self {
+        let mut data = self.data.synced.lock();
+        data.senders += 1;
+        drop(data);
+        Self {
+            data: self.data.clone(),
+        }
+    }
+}
+
+impl<T> Drop for Broadcaster<T> {
+    fn drop(&mut self) {
+        let mut data = self.data.synced.lock();
+        data.senders -= 1;
+
+        let notify_disconnected = data.senders == 0;
+        if notify_disconnected {
+            for waker in data.wakers.drain(..) {
+                waker.wake();
+            }
+        }
+        drop(data);
+        if notify_disconnected {
+            self.data.condvar.notify_all();
+            enqueue_task(BackgroundTask::Channel(ChannelTask::Unregister(
+                channel_id(&self.data),
+            )));
+        }
+    }
+}
+
+/// A future that broadcasts a value to a [`BroadcastChannel<T>`].
+#[must_use = "Futures must be awaited to be executed"]
+pub struct BroadcastAsync<'a, T> {
+    value: Option<T>,
+    channel: &'a Arc<ChannelData<T, MultipleCallbacks<T>>>,
+}
+
+impl<T> Future for BroadcastAsync<'_, T>
+where
+    T: Unpin + Clone + Send + 'static,
+{
+    type Output = Option<T>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let Some(value) = self.value.take() else {
+            return Poll::Ready(None);
+        };
+        match self
+            .channel
+            .try_send_inner(value, channel_id(self.channel), |channel| {
+                let will_wake = channel
+                    .wakers
+                    .iter()
+                    .any(|waker| waker.will_wake(cx.waker()));
+                if !will_wake {
+                    channel.wakers.push(cx.waker().clone());
+                }
+                ControlFlow::Break(())
+            }) {
+            Ok(()) => Poll::Ready(None),
+            Err(TrySendError::Disconnected(value)) => Poll::Ready(Some(value)),
+            Err(TrySendError::Full(value)) => {
+                self.value = Some(value);
+                Poll::Pending
+            }
+        }
+    }
 }
 
 impl<F, T> AnyChannelCallback<T> for F
@@ -472,46 +1172,323 @@ where
     }
 }
 
-enum ChannelCallbackError {
-    Async(Box<dyn Future<Output = Result<(), CallbackDisconnected>>>),
+fn channel_id<T, Behavior>(data: &Arc<ChannelData<T, Behavior>>) -> usize {
+    Arc::as_ptr(data) as usize
+}
+
+/// A receiver for values sent by a [`Sender`].
+pub struct Receiver<T> {
+    data: Arc<ChannelData<T, SingleCallback<T>>>,
+}
+
+impl<T> Receiver<T>
+where
+    T: Send + 'static,
+{
+    /// Returns the next value, blocking the current thread until one is
+    /// available.
+    ///
+    /// Returns `None` if there are no [`Sender`]s still connected to this
+    /// channel.
+    #[must_use]
+    pub fn receive(&self) -> Option<T> {
+        self.try_receive_inner(|guard| {
+            self.data.condvar.wait(guard);
+            ControlFlow::Continue(())
+        })
+        .ok()
+    }
+
+    /// Returns the next value if possible, otherwise returning an error
+    /// describing why a value was unable to be received.
+    ///
+    /// This function will not block the current thread.
+    pub fn try_receive(&self) -> Result<T, TryReceiveError> {
+        self.try_receive_inner(|_guard| ControlFlow::Break(()))
+    }
+
+    fn try_receive_inner(
+        &self,
+        mut when_empty: impl FnMut(
+            &mut MutexGuard<'_, SyncedChannelData<T, SingleCallback<T>>>,
+        ) -> ControlFlow<()>,
+    ) -> Result<T, TryReceiveError> {
+        let mut data = self.data.synced.lock();
+        loop {
+            if let Some(value) = data.queue.pop_front() {
+                for waker in data.wakers.drain(..) {
+                    waker.wake();
+                }
+                drop(data);
+                self.data.condvar.notify_all();
+                return Ok(value);
+            }
+
+            if data.senders == 0 {
+                return Err(TryReceiveError::Disconnected);
+            }
+
+            if when_empty(&mut data).is_break() {
+                return Err(TryReceiveError::Empty);
+            }
+        }
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel.
+    ///
+    /// This function assumes `on_receive` may block while waiting on another
+    /// thread, another process, another callback, a network request, a locking
+    /// primitive, or any other number of ways that could impact other callbacks
+    /// from executing.
+    pub fn on_receive<Map>(self, mut on_receive: Map)
+    where
+        Map: FnMut(T) + Send + 'static,
+    {
+        self.on_receive_try(move |value| {
+            on_receive(value);
+            Ok(())
+        });
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel. Once an
+    /// error is returned, this callback will be removed from the channel.
+    ///
+    /// This function assumes `on_receive` may block while waiting on another
+    /// thread, another process, another callback, a network request, a locking
+    /// primitive, or any other number of ways that could impact other callbacks
+    /// from executing.
+    ///
+    /// Once the last callback associated with a channel is removed, [`Sender`]s
+    /// will begin returning disconnected errors.
+    pub fn on_receive_try<Map>(self, on_receive: Map)
+    where
+        Map: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
+    {
+        self.on_receive_inner(CallbackKind::Blocking(Box::new(on_receive)));
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel.
+    ///
+    /// This function assumes `on_receive` will not block while waiting on
+    /// another thread, another process, another callback, a network request, a
+    /// locking primitive, or any other number of ways that could impact other
+    /// callbacks from executing in a shared environment.
+    pub fn on_receive_nonblocking<Map>(self, mut on_receive: Map)
+    where
+        Map: FnMut(T) + Send + 'static,
+    {
+        self.on_receive_nonblocking_try(move |value| {
+            on_receive(value);
+            Ok(())
+        });
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel. Once an
+    /// error is returned, this callback will be removed from the channel.
+    ///
+    /// This function assumes `on_receive` will not block while waiting on
+    /// another thread, another process, another callback, a network request, a
+    /// locking primitive, or any other number of ways that could impact other
+    /// callbacks from executing in a shared environment.
+    ///
+    /// Once the last callback associated with a channel is removed, [`Sender`]s
+    /// will begin returning disconnected errors.
+    pub fn on_receive_nonblocking_try<Map>(self, mut on_receive: Map)
+    where
+        Map: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
+    {
+        self.on_receive_inner(CallbackKind::NonBlocking(Box::new(move |value| {
+            on_receive(value).map_err(|CallbackDisconnected| ChannelCallbackError::Disconnected)
+        })));
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel.
+    pub fn on_receive_async<Map, Fut>(self, mut on_receive: Map)
+    where
+        Map: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_receive_async_try(move |value| {
+            let future = on_receive(value);
+            async move {
+                future.await;
+                Ok(())
+            }
+        });
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel. The
+    /// returned future will then be awaited. Once an error is returned, this
+    /// callback will be removed from the channel.
+    ///
+    /// Once the last callback associated with a channel is removed, [`Sender`]s
+    /// will begin returning disconnected errors.
+    pub fn on_receive_async_try<Map, Fut>(self, mut on_receive: Map)
+    where
+        Map: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(), CallbackDisconnected>> + Send + 'static,
+    {
+        self.on_receive_inner(CallbackKind::NonBlocking(Box::new(move |value| {
+            let future = on_receive(value);
+            Err(ChannelCallbackError::Async(Box::pin(future)))
+        })));
+    }
+
+    fn on_receive_inner(self, cb: CallbackKind<T>) {
+        match cb {
+            CallbackKind::Blocking(fn_mut) => {
+                self.spawn_thread(fn_mut);
+            }
+            CallbackKind::NonBlocking(cb) => {
+                let mut data = self.data.synced.lock();
+                data.behavior = SingleCallback::Callback(cb);
+                drop(data);
+                enqueue_task(BackgroundTask::Channel(ChannelTask::Register {
+                    id: channel_id(&self.data),
+                    data: Arc::new(self.data.clone()),
+                }));
+            }
+        }
+    }
+
+    fn spawn_thread(
+        self,
+        mut cb: Box<dyn FnMut(T) -> Result<(), super::CallbackDisconnected> + Send + 'static>,
+    ) {
+        std::thread::spawn(move || {
+            while let Some(value) = self.receive() {
+                if let Err(CallbackDisconnected) = cb(value) {
+                    return;
+                }
+            }
+        });
+    }
+}
+
+impl<T> Future for &Receiver<T>
+where
+    T: Unpin + Send + 'static,
+{
+    type Output = Option<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.try_receive_inner(|guard| {
+            let will_wake = guard.wakers.iter().any(|w| w.will_wake(cx.waker()));
+            if !will_wake {
+                guard.wakers.push(cx.waker().clone());
+            }
+            ControlFlow::Break(())
+        }) {
+            Ok(value) => Poll::Ready(Some(value)),
+            Err(TryReceiveError::Disconnected) => Poll::Ready(None),
+            Err(TryReceiveError::Empty) => Poll::Pending,
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        let mut data = self.data.synced.lock();
+        data.receivers -= 1;
+        if matches!(data.behavior, SingleCallback::Receiver) {
+            data.behavior = SingleCallback::Disconnected;
+        }
+        for waker in data.wakers.drain(..) {
+            waker.wake();
+        }
+        drop(data);
+        self.data.condvar.notify_all();
+    }
+}
+
+/// An error trying to receive a value from a channel.
+pub enum TryReceiveError {
+    /// The channel was empty.
+    Empty,
+    /// The channel has no senders connected.
     Disconnected,
 }
 
 #[test]
 fn channel_basics() {
-    use crate::value::{Destination, Dynamic, Source};
-    let result = Dynamic::new(0);
-    let result_reader = result.create_reader();
-    let channel = Channel::<usize>::unbounded(move |value| result.set(dbg!(value)));
-    assert!(!result_reader.has_updated());
-    channel.send(1);
-    result_reader.block_until_updated();
-    assert_eq!(result_reader.get(), 1);
+    let (result_sender, result_receiver) = unbounded();
+
+    let sender = Builder::new()
+        .on_receive_nonblocking(move |value| result_sender.send(dbg!(value)).unwrap())
+        .finish();
+    sender.send(1).unwrap();
+
+    assert_eq!(result_receiver.receive().unwrap(), 1);
+    drop(sender);
+    assert_eq!(result_receiver.receive(), None);
+}
+
+#[test]
+fn send_then_spawn() {
+    let (result_sender, result_receiver) = unbounded();
+
+    let (sender, receiver) = Builder::new().finish();
+    sender.send(1).unwrap();
+    receiver.on_receive_nonblocking(move |value| result_sender.send(dbg!(value)).unwrap());
+
+    assert_eq!(result_receiver.receive().unwrap(), 1);
+    drop(sender);
+    assert_eq!(result_receiver.receive(), None);
+}
+
+#[test]
+fn disconnected_send() {
+    let (sender, receiver) = Builder::new().finish();
+    // Sending is allowed while a receiver could theoretically receive it.
+    sender.send(1).unwrap();
+    drop(receiver);
+    assert_eq!(sender.send(2), Err(2));
+}
+
+#[test]
+fn broadcast_basic() {
+    let (result_sender, result_receiver) = unbounded();
+
+    let channel = Builder::new()
+        .broadcasting()
+        .on_receive_nonblocking({
+            let result_sender = result_sender.clone();
+            move |value| {
+                result_sender.send(value).unwrap();
+            }
+        })
+        .on_receive_nonblocking({
+            move |value| {
+                result_sender.send(value).unwrap();
+            }
+        })
+        .finish();
+    channel.send(1).unwrap();
+
+    assert_eq!(result_receiver.receive(), Some(1));
+    assert_eq!(result_receiver.receive(), Some(1));
+    drop(channel);
+    assert_eq!(result_receiver.receive(), None);
 }
 
 #[test]
 fn async_channels() {
-    use crate::value::{Destination, Dynamic, Source};
+    let (a_sender, a_receiver) = bounded(1);
+    let (b_sender, b_receiver) = bounded(1);
 
-    let result = Dynamic::new(0);
-    let result_reader = result.create_reader();
-    let channel2 = Channel::<usize>::unbounded_async(move |value| {
-        let result = result.clone();
+    a_receiver.on_receive_async(move |value| {
+        let b_sender = b_sender.clone();
         async move {
-            result.set(dbg!(value));
+            for i in 0..value {
+                b_sender.send_async(dbg!(i)).await.unwrap();
+            }
         }
     });
-    let channel1 = Channel::<usize>::unbounded_async(move |value| {
-        let channel2 = channel2.clone();
-        async move {
-            channel2.send(dbg!(value));
-        }
-    });
-    assert!(!result_reader.has_updated());
-    channel1.send(1);
-    result_reader.block_until_updated();
-    assert_eq!(result_reader.get(), 1);
-    channel1.send(2);
-    result_reader.block_until_updated();
-    assert_eq!(result_reader.get(), 2);
+    a_sender.send(5).unwrap();
+    for i in 0..5 {
+        println!("Reading {i}");
+        assert_eq!(b_receiver.receive(), Some(i));
+    }
+    drop(a_sender);
+    assert_eq!(b_receiver.receive(), None);
 }

--- a/src/reactive/channel/builder.rs
+++ b/src/reactive/channel/builder.rs
@@ -1,0 +1,341 @@
+//! Builder types for Cushy [`channel`](super)qs.
+use std::future::Future;
+use std::marker::PhantomData;
+
+use super::sealed::{CallbackKind, ChannelCallbackError};
+use super::{
+    BroadcastCallback, BroadcastChannel, ChannelData, MultipleCallbacks, Receiver, Sender,
+};
+use crate::value::CallbackDisconnected;
+
+/// Builds a Cushy channel.
+///
+/// This type can be used to create all types of channels supported by Cushy.
+/// See the [`channel`](self) module documentation for an overview of the
+/// channels provided.
+#[must_use]
+pub struct Builder<T, Mode = SingleConsumer> {
+    mode: Mode,
+    ty: PhantomData<T>,
+    bound: Option<usize>,
+}
+
+impl<T> Default for Builder<T, SingleConsumer> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Builder<T, SingleConsumer> {
+    /// Returns a builder for a Cushy channel.
+    ///
+    /// The default builder will create an unbounded, Multi-Producer,
+    /// Single-Consumer channel. See the [`channel`](self) module documentation
+    /// for an overview of the channels provided.
+    pub const fn new() -> Self {
+        Self {
+            mode: SingleConsumer { _private: () },
+            ty: PhantomData,
+            bound: None,
+        }
+    }
+}
+
+impl<T, Mode> Builder<T, Mode>
+where
+    T: Send + 'static,
+    Mode: ChannelMode<T> + sealed::ChannelMode<T, Next = <Mode as ChannelMode<T>>::Next>,
+{
+    /// Invokes `on_receive` each time a value is sent to this channel.
+    ///
+    /// This function assumes `on_receive` may block while waiting on another
+    /// thread, another process, another callback, a network request, a locking
+    /// primitive, or any other number of ways that could impact other callbacks
+    /// from executing.
+    pub fn on_receive<Map>(self, mut on_receive: Map) -> Builder<T, <Mode as ChannelMode<T>>::Next>
+    where
+        Map: FnMut(T) + Send + 'static,
+    {
+        self.on_receive_try(move |value| {
+            on_receive(value);
+            Ok(())
+        })
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel. Once an
+    /// error is returned, this callback will be removed from the channel.
+    ///
+    /// This function assumes `on_receive` may block while waiting on another
+    /// thread, another process, another callback, a network request, a locking
+    /// primitive, or any other number of ways that could impact other callbacks
+    /// from executing.
+    ///
+    /// Once the last callback associated with a channel is removed, [`Sender`]s
+    /// will begin returning disconnected errors.
+    pub fn on_receive_try<Map>(self, map: Map) -> Builder<T, <Mode as ChannelMode<T>>::Next>
+    where
+        Map: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
+    {
+        Builder {
+            mode: self
+                .mode
+                .push_callback(CallbackKind::Blocking(Box::new(map))),
+            bound: self.bound,
+            ty: self.ty,
+        }
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel.
+    ///
+    /// This function assumes `on_receive` will not block while waiting on
+    /// another thread, another process, another callback, a network request, a
+    /// locking primitive, or any other number of ways that could impact other
+    /// callbacks from executing in a shared environment.
+    pub fn on_receive_nonblocking<Map>(
+        self,
+        mut on_receive: Map,
+    ) -> Builder<T, <Mode as ChannelMode<T>>::Next>
+    where
+        Map: FnMut(T) + Send + 'static,
+    {
+        self.on_receive_nonblocking_try(move |value| {
+            on_receive(value);
+            Ok(())
+        })
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel. Once an
+    /// error is returned, this callback will be removed from the channel.
+    ///
+    /// This function assumes `on_receive` will not block while waiting on
+    /// another thread, another process, another callback, a network request, a
+    /// locking primitive, or any other number of ways that could impact other
+    /// callbacks from executing in a shared environment.
+    ///
+    /// Once the last callback associated with a channel is removed, [`Sender`]s
+    /// will begin returning disconnected errors.
+    pub fn on_receive_nonblocking_try<Map>(
+        self,
+        mut map: Map,
+    ) -> Builder<T, <Mode as ChannelMode<T>>::Next>
+    where
+        Map: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
+    {
+        Builder {
+            mode: self
+                .mode
+                .push_callback(CallbackKind::NonBlocking(Box::new(move |value| {
+                    map(value).map_err(|CallbackDisconnected| ChannelCallbackError::Disconnected)
+                }))),
+            bound: self.bound,
+            ty: self.ty,
+        }
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel.
+    pub fn on_receive_async<Map, Fut>(
+        self,
+        mut on_receive: Map,
+    ) -> Builder<T, <Mode as ChannelMode<T>>::Next>
+    where
+        Map: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_receive_async_try(move |value| {
+            let future = on_receive(value);
+            async move {
+                future.await;
+                Ok(())
+            }
+        })
+    }
+
+    /// Invokes `on_receive` each time a value is sent to this channel. The
+    /// returned future will then be awaited. Once an error is returned, this
+    /// callback will be removed from the channel.
+    ///
+    /// Once the last callback associated with a channel is removed, [`Sender`]s
+    /// will begin returning disconnected errors.
+    pub fn on_receive_async_try<Map, Fut>(
+        self,
+        mut on_receive: Map,
+    ) -> Builder<T, <Mode as ChannelMode<T>>::Next>
+    where
+        Map: FnMut(T) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(), CallbackDisconnected>> + Send + 'static,
+    {
+        Builder {
+            mode: self
+                .mode
+                .push_callback(CallbackKind::NonBlocking(Box::new(move |value| {
+                    let future = on_receive(value);
+                    Err(ChannelCallbackError::Async(Box::pin(future)))
+                }))),
+            bound: self.bound,
+            ty: self.ty,
+        }
+    }
+
+    /// Returns this builder reconfigured to create a [`BroadcastChannel`].
+    ///
+    /// See the [`channel`](self) module documentation for an overview of the
+    /// channels provided.
+    pub fn broadcasting(self) -> Builder<T, Broadcast<T>> {
+        Builder {
+            mode: self.mode.into(),
+            ty: self.ty,
+            bound: self.bound,
+        }
+    }
+
+    /// Restricts this channel to `capacity` values queued.
+    pub fn bounded(mut self, capacity: usize) -> Self {
+        self.bound = Some(capacity);
+        self
+    }
+
+    /// Returns the finished channel.
+    pub fn finish(self) -> Mode::Channel {
+        self.mode.finish(self.bound)
+    }
+}
+
+/// Builder configuration for a single-consumer channel with no associated
+/// callback.
+pub struct SingleConsumer {
+    _private: (),
+}
+
+impl<T> ChannelMode<T> for SingleConsumer
+where
+    T: Send + 'static,
+{
+    type Channel = (Sender<T>, Receiver<T>);
+    type Next = SingleCallback<T>;
+
+    fn finish(self, limit: Option<usize>) -> Self::Channel {
+        let data = ChannelData::new(limit, super::SingleCallback::Receiver, 1, 1);
+
+        (Sender { data: data.clone() }, Receiver { data })
+    }
+}
+
+impl<T> sealed::ChannelMode<T> for SingleConsumer {
+    type Next = SingleCallback<T>;
+
+    fn push_callback(self, cb: CallbackKind<T>) -> Self::Next {
+        SingleCallback { cb }
+    }
+}
+
+impl<T> From<SingleConsumer> for Broadcast<T> {
+    fn from(_: SingleConsumer) -> Self {
+        Self {
+            callbacks: Vec::new(),
+        }
+    }
+}
+
+/// Builder configuration for a single-consumer channel with an associated
+/// callback.
+pub struct SingleCallback<T> {
+    cb: CallbackKind<T>,
+}
+
+impl<T> ChannelMode<T> for SingleCallback<T>
+where
+    T: Send + 'static,
+{
+    type Channel = Sender<T>;
+    type Next = Broadcast<T>;
+
+    fn finish(self, limit: Option<usize>) -> Self::Channel {
+        let data = match self.cb {
+            CallbackKind::Blocking(cb) => {
+                let data = ChannelData::new(limit, super::SingleCallback::Receiver, 1, 1);
+                let receiver = Receiver { data: data.clone() };
+                receiver.spawn_thread(cb);
+                data
+            }
+            CallbackKind::NonBlocking(cb) => {
+                ChannelData::new(limit, super::SingleCallback::Callback(cb), 1, 0)
+            }
+        };
+        Sender { data }
+    }
+}
+
+impl<T> sealed::ChannelMode<T> for SingleCallback<T> {
+    type Next = Broadcast<T>;
+
+    fn push_callback(self, cb: CallbackKind<T>) -> Self::Next {
+        Broadcast {
+            callbacks: vec![cb],
+        }
+    }
+}
+
+impl<T> From<SingleCallback<T>> for Broadcast<T> {
+    fn from(single: SingleCallback<T>) -> Self {
+        Self {
+            callbacks: vec![single.cb],
+        }
+    }
+}
+
+/// Builder configuration for a [`BroadcastChannel`].
+pub struct Broadcast<T> {
+    callbacks: Vec<CallbackKind<T>>,
+}
+
+impl<T> ChannelMode<T> for Broadcast<T>
+where
+    T: Unpin + Clone + Send + 'static,
+{
+    type Channel = BroadcastChannel<T>;
+    type Next = Self;
+
+    fn finish(self, limit: Option<usize>) -> Self::Channel {
+        let callbacks = self
+            .callbacks
+            .into_iter()
+            .map(|cb| match cb {
+                CallbackKind::Blocking(cb) => BroadcastCallback::spawn_blocking(cb),
+                CallbackKind::NonBlocking(cb) => BroadcastCallback::NonBlocking(cb),
+            })
+            .collect();
+        let data = ChannelData::new(limit, MultipleCallbacks(callbacks), 1, 1);
+        BroadcastChannel { data }
+    }
+}
+
+impl<T> sealed::ChannelMode<T> for Broadcast<T> {
+    type Next = Self;
+
+    fn push_callback(mut self, cb: CallbackKind<T>) -> Self::Next {
+        self.callbacks.push(cb);
+        self
+    }
+}
+
+/// A channel configuration.
+pub trait ChannelMode<T>: Into<Broadcast<T>> {
+    /// The next configuration when a new callback is associated with this
+    /// builder.
+    type Next;
+    /// The resulting channel type created from this configuration.
+    type Channel;
+
+    /// Returns the built channel.
+    fn finish(self, limit: Option<usize>) -> Self::Channel;
+}
+
+mod sealed {
+    use crate::channel::sealed::CallbackKind;
+
+    pub trait ChannelMode<T> {
+        type Next;
+
+        fn push_callback(self, callback: CallbackKind<T>) -> Self::Next;
+    }
+}

--- a/src/reactive/value.rs
+++ b/src/reactive/value.rs
@@ -299,12 +299,39 @@ pub trait Source<T> {
 
     /// Invokes `for_each` with the current contents and each time this source's
     /// contents are updated.
+    ///
+    /// Returning `Err(CallbackDisconnected)` will prevent the callback from
+    /// being invoked again.
     fn for_each_cloned_try<F>(&self, mut for_each: F) -> CallbackHandle
     where
         T: Clone + Send + 'static,
         F: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
     {
         self.for_each_generational_cloned_try(move |gen| for_each(gen.value))
+    }
+
+    /// Invokes `for_each` each time this source's contents are updated.
+    ///
+    /// Returning `Err(CallbackDisconnected)` will prevent the callback from
+    /// being invoked again.
+    fn for_each_subsequent_cloned_try<F>(&self, mut for_each: F) -> CallbackHandle
+    where
+        T: Clone + Send + 'static,
+        F: FnMut(T) -> Result<(), CallbackDisconnected> + Send + 'static,
+    {
+        self.for_each_subsequent_generational_cloned_try(move |gen| for_each(gen.value))
+    }
+
+    /// Invokes `for_each` each time this source's contents are updated.
+    fn for_each_subsequent_cloned<F>(&self, mut for_each: F) -> CallbackHandle
+    where
+        T: Clone + Send + 'static,
+        F: FnMut(T) + Send + 'static,
+    {
+        self.for_each_subsequent_cloned_try(move |value| {
+            for_each(value);
+            Ok(())
+        })
     }
 
     /// Invokes `for_each` with the current contents and each time this source's


### PR DESCRIPTION
This new type isn't integrated in with any of the existing types yet. This is a step towards what is needed to implement the command pattern, which I think is the best approach for #192.

I think we might need a Broadcast channel type as well to allow a channel type where multiple callbacks can be associated rather than a single, but it will require a Clone bound or extra allocations and the current implementation doesn't need either.