### PR TITLE
Add `force_set` to Value API

### DIFF
--- a/src/reactive/value.rs
+++ b/src/reactive/value.rs
@@ -636,15 +636,24 @@ pub trait Destination<T> {
     /// "noisy". Cushy attempts to minimize noise by only invoking callbacks
     /// when the value has changed, and it detects this by using `PartialEq`.
     ///
-    /// However, not all types implement `PartialEq`.
-    /// [`map_mut()`](Self::map_mut) does not require `PartialEq`, and will
-    /// invoke change callbacks after accessing exclusively.
+    /// However, not all types implement `PartialEq`. See [`force_set()`](Self::force_set).
     fn set(&self, new_value: T)
     where
         T: PartialEq,
     {
         let _old = self.replace(new_value);
     }
+
+    /// Stores `new_value` in this dynamic without checking for equality.
+    ///
+    /// Before returning from this function, all observers will be notified
+    /// that the contents have been updated.
+    fn force_set(&self, new_value: T) {
+        self.map_mut(|mut old_value|{
+            let _old_value = std::mem::replace(&mut *old_value, new_value);
+        });
+    }
+
 
     /// Replaces the current value with `new_value` if the current value is
     /// equal to `expected_current`.


### PR DESCRIPTION
In my 'makerpnp' application which uses a `Dynamic<Message>`, where the `Message` enum does not implement `PartialEq` because some of the values it contains are do not implement `PartialEq`, I found it very un-ergonomic to use `map_mut` and have been using the `force_set` from this PR instead for a while now.

example code from my app:

```rust
let ok_button = "Ok".into_button()
    .on_click({
        let message = self.message.clone();
        move |_event| message.force_set(Message::SomeEvent(event_args))
    });
```

I looked at calling `force_set` replace, but that already exists for types that implement `PartialEq`, also in my use-case the caller does not need the old value like `set`.

This PR also fixes the rustdoc documentation on the `set` method which didn't seem correct.
